### PR TITLE
docs(850267): Keytip documentation added.

### DIFF
--- a/ej2-javascript/code-snippet/ribbon/backstagemenu-keytip/index.js
+++ b/ej2-javascript/code-snippet/ribbon/backstagemenu-keytip/index.js
@@ -1,0 +1,58 @@
+var tabs = [
+  {
+    header: "Home",
+    groups: [
+      {
+        header: "Clipboard",
+        collections: [
+          {
+            items: [
+              {
+                type: "Button",
+                buttonSettings: {
+                  content: "Paste",
+                  iconCss: "e-icons e-paste",
+                }
+              },
+            ],
+          },
+          {
+            items: [
+              {
+                type: "Button",
+                buttonSettings: {
+                  content: "Cut",
+                  iconCss: "e-icons e-cut",
+                }
+              },
+              {
+                type: "Button",
+                buttonSettings: {
+                  content: "Copy",
+                  iconCss: "e-icons e-copy",
+                }
+              },
+            ],
+          }
+        ]
+      }
+    ]
+  }
+];
+
+var ribbon = new ej.ribbon.Ribbon({
+    tabs: tabs,
+    backStageMenu: {
+      keyTip: 'F',
+      items: [
+        { id: 'home', keyTip: 'H', text: 'Home', iconCss: 'e-icons e-home', content: '#homeContent' },
+        { id: 'new', keyTip: 'N', text: 'New', iconCss: 'e-icons e-file-new', content: '#newContent' },
+        { id: 'open', keyTip: 'O', text: 'Open', iconCss: 'e-icons e-folder-open', content: '#openContent' }
+      ],
+      visible: true,
+      backButton: { text: 'Close' }
+    },
+    enableKeyTips: true
+});
+ribbon.appendTo("#ribbon");
+ribbon.ribbonKeyTipModule.showKeyTips('F');

--- a/ej2-javascript/code-snippet/ribbon/backstagemenu-keytip/index.js
+++ b/ej2-javascript/code-snippet/ribbon/backstagemenu-keytip/index.js
@@ -8,10 +8,12 @@ var tabs = [
           {
             items: [
               {
-                type: "Button",
-                buttonSettings: {
-                  content: "Paste",
-                  iconCss: "e-icons e-paste",
+                type: 'SplitButton',
+                allowedSizes: ej.ribbon.RibbonItemSize.Large,
+                splitButtonSettings: {
+                  content: 'Paste',
+                  iconCss: 'e-icons e-paste',
+                  items: [{ text: 'Keep Source Format' }, { text: 'Merge format' }, { text: 'Keep text only' }]
                 }
               },
             ],

--- a/ej2-javascript/code-snippet/ribbon/backstagemenu-keytip/index.ts
+++ b/ej2-javascript/code-snippet/ribbon/backstagemenu-keytip/index.ts
@@ -1,6 +1,6 @@
 
 
-import { Ribbon, RibbonTabModel, RibbonItemType, RibbonBackstage, RibbonKeyTip } from "@syncfusion/ej2-ribbon";
+import { Ribbon, RibbonTabModel, RibbonItemType, RibbonItemSize, RibbonBackstage, RibbonKeyTip } from "@syncfusion/ej2-ribbon";
 
 Ribbon.Inject(RibbonBackstage, RibbonKeyTip);
 
@@ -14,10 +14,12 @@ let tabs: RibbonTabModel[] = [
           {
             items: [
               {
-                type: RibbonItemType.Button,
-                buttonSettings: {
-                  content: "Paste",
-                  iconCss: "e-icons e-paste",
+                type: RibbonItemType.SplitButton,
+                allowedSizes: RibbonItemSize.Large,
+                splitButtonSettings: {
+                    content: 'Paste',
+                    iconCss: 'e-icons e-paste',
+                    items: [{ text: 'Keep Source Format' }, { text: 'Merge format' }, { text: 'Keep text only' }]
                 }
               },
             ],
@@ -61,5 +63,4 @@ let ribbon: Ribbon = new Ribbon({
     enableKeyTips: true
 });
 ribbon.appendTo("#ribbon");
-
-
+ribbon.ribbonKeyTipModule.showKeyTips('F');

--- a/ej2-javascript/code-snippet/ribbon/backstagemenu-keytip/index.ts
+++ b/ej2-javascript/code-snippet/ribbon/backstagemenu-keytip/index.ts
@@ -1,0 +1,65 @@
+
+
+import { Ribbon, RibbonTabModel, RibbonItemType, RibbonBackstage, RibbonKeyTip } from "@syncfusion/ej2-ribbon";
+
+Ribbon.Inject(RibbonBackstage, RibbonKeyTip);
+
+let tabs: RibbonTabModel[] = [
+  {
+    header: "Home",
+    groups: [
+      {
+        header: "Clipboard",
+        collections: [
+          {
+            items: [
+              {
+                type: RibbonItemType.Button,
+                buttonSettings: {
+                  content: "Paste",
+                  iconCss: "e-icons e-paste",
+                }
+              },
+            ],
+          },
+          {
+            items: [
+              {
+                type: RibbonItemType.Button,
+                buttonSettings: {
+                  content: "Cut",
+                  iconCss: "e-icons e-cut",
+                }
+              },
+              {
+                type: RibbonItemType.Button,
+                buttonSettings: {
+                  content: "Copy",
+                  iconCss: "e-icons e-copy",
+                }
+              },
+            ],
+          }
+        ]
+      }
+    ]
+  }
+];
+
+let ribbon: Ribbon = new Ribbon({
+    tabs: tabs,
+    backStageMenu: {
+      keyTip: 'F',
+      items: [
+        { id: 'home', keyTip: 'H', text: 'Home', iconCss: 'e-icons e-home', content: '#homeContent' },
+        { id: 'new', keyTip: 'N', text: 'New', iconCss: 'e-icons e-file-new', content: '#newContent' },
+        { id: 'open', keyTip: 'O', text: 'Open', iconCss: 'e-icons e-folder-open', content: '#openContent' }
+      ],
+      visible: true,
+      backButton: { text: 'Close' }
+    },
+    enableKeyTips: true
+});
+ribbon.appendTo("#ribbon");
+
+

--- a/ej2-javascript/code-snippet/ribbon/backstagemenu-keytip/js/index.html
+++ b/ej2-javascript/code-snippet/ribbon/backstagemenu-keytip/js/index.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<script src="https://cdn.syncfusion.com/ej2/syncfusion-helper.js"></script>
+    <title>Essential JS 2 - Ribbon</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="description" content="Essential JS 2">
+    <meta name="author" content="Syncfusion">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-base/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-buttons/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-popups/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-splitbuttons/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-inputs/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-lists/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-dropdowns/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-navigations/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-ribbon/styles/material.css" rel="stylesheet">
+
+    <!--style reference from app-->
+    <link href="styles.css" rel="stylesheet">
+
+    <!--system js reference and configuration-->
+    
+    
+<script src="https://cdn.syncfusion.com/ej2/20.3.56/dist/ej2.min.js" type="text/javascript"></script>
+</head>
+<body>
+    
+    <div id="container">
+        <div id="ribbon"></div>
+    </div>
+
+<script type="text/x-jsrender" id="homeContent">
+    <div id='home-wrapper' style="padding: 20px;">
+        <div id='new-section' class='new-wrapper'>
+            <div class='section-title'> New </div>
+            <div class='category_container'>
+                <div class='doc_category_image'></div> 
+                <span class='doc_category_text'> New document </span>
+            </div>
+        </div>
+        <div id='block-wrapper'><div class='section-title'> Recent </div>
+            <div class="section-content" style="padding: 12px 0px; cursor: pointer">
+                <table>
+                    <tbody>
+                        <tr>
+                            <td> <span class="doc_icon e-icons e-open-link"></span> </td>
+                            <td> 
+                                <span style="display: block; font-size: 14px"> Ribbon.docx </span>
+                                <span style="font-size: 12px"> EJ2 >> Components >> Navigations >> Ribbon >> default </span>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</script>
+<script type="text/x-jsrender" id="newContent">
+    <div id='new-content' style="padding: 20px;">
+        <div id='new-section' class='new-wrapper'>
+            <div class='section-title'> New </div>
+            <div class='category_container'>
+                <div class='doc_category_image'></div> 
+                <span class='doc_category_text'> New document </span>
+            </div>
+        </div>
+    </div>
+</script>
+<script type="text/x-jsrender" id="openContent">
+    <div style="padding: 20px;">
+        <div class="section-content" style="padding: 12px 0px; cursor: pointer">
+            <table>
+                <tbody>
+                    <tr>
+                        <td> <span class="doc_icon e-icons e-open-link"></span> </td>
+                        <td> 
+                            <span style="display: block; font-size: 14px"> Open in Desktop App </span>
+                            <span style="font-size: 12px"> Use the full functionality of Ribbon </span>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <div class="section-content" style="padding: 12px 0px cursor: pointer">
+            <table>
+                <tbody>
+                    <tr>
+                        <td> <span class="doc_icon e-icons e-protect-sheet"></span> </td>
+                        <td> 
+                            <span style="display: block; font-size: 14px"> Protect Document </span>
+                            <span style="font-size: 12px">To prevent accidental changes,
+                                this document has been set to open as view-only.</span>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</script>
+<script>
+var ele = document.getElementById('container');
+if(ele) {
+    ele.style.visibility = "visible";
+ }   
+        </script>
+<script src="index.js" type="text/javascript"></script>
+</body></html>

--- a/ej2-javascript/code-snippet/ribbon/backstagemenu-keytip/styles.css
+++ b/ej2-javascript/code-snippet/ribbon/backstagemenu-keytip/styles.css
@@ -1,0 +1,51 @@
+.e-ribbon-backstage-content{
+    width: 550px;
+    height: 350px;
+}
+
+.section-title {
+    font-size: 22px;
+}
+
+.new-docs {
+    display: flex;
+    justify-content: space-around;
+    flex-wrap: wrap;
+}
+
+.category_container {
+    width: 150px;
+    padding: 15px;
+    text-align: center;
+    cursor: pointer;
+}
+
+.doc_category_image {
+    width: 80px;
+    height: 100px;
+    background-color: #fff;
+    border: 1px solid rgb(125, 124, 124);
+    text-align: center;
+    overflow: hidden;
+    margin: 0px auto 10px;
+}
+
+.doc_category_text {
+    font-size: 16px;
+}
+
+.section-content {
+    padding: 12px 0px;
+    cursor: pointer;
+}
+
+.doc_icon {
+    font-size: 16px;
+    padding: 0px 10px;
+}
+
+.category_container:hover, .section-content:hover {
+    background-color: #dfdfdf;
+    border-radius: 5px;
+    transition: all 0.3s;
+}

--- a/ej2-javascript/code-snippet/ribbon/backstagemenu-keytip/systemjs.config.js
+++ b/ej2-javascript/code-snippet/ribbon/backstagemenu-keytip/systemjs.config.js
@@ -1,0 +1,35 @@
+System.config({
+    transpiler: "typescript",
+    typescriptOptions: {
+        compilerOptions: {
+            target: "umd",
+            module: "commonjs",
+            moduleResolution: "node",
+            emitDecoratorMetadata: true,
+            experimentalDecorators: true
+        }
+    },
+    paths: {
+        "syncfusion:": "https://cdn.syncfusion.com/ej2/20.3.56/"
+    },
+    map: {
+        main: "index.ts",
+        typescript: "https://unpkg.com/typescript@2.2.2/lib/typescript.js",
+        "@syncfusion/ej2-base": "syncfusion:ej2-base/dist/ej2-base.umd.min.js",
+        "@syncfusion/ej2-data": "syncfusion:ej2-data/dist/ej2-data.umd.min.js",
+        "@syncfusion/ej2-buttons": "syncfusion:ej2-buttons/dist/ej2-buttons.umd.min.js",
+        "@syncfusion/ej2-splitbuttons": "syncfusion:ej2-splitbuttons/dist/ej2-splitbuttons.umd.min.js",
+        "@syncfusion/ej2-popups": "syncfusion:ej2-popups/dist/ej2-popups.umd.min.js",
+        "@syncfusion/ej2-inputs": "syncfusion:ej2-inputs/dist/ej2-inputs.umd.min.js",
+        "@syncfusion/ej2-lists": "syncfusion:ej2-lists/dist/ej2-lists.umd.min.js",
+        "@syncfusion/ej2-dropdowns": "syncfusion:ej2-dropdowns/dist/ej2-dropdowns.umd.min.js",
+        "@syncfusion/ej2-navigations": "syncfusion:ej2-navigations/dist/ej2-navigations.umd.min.js",
+        "@syncfusion/ej2-ribbon": "syncfusion:ej2-ribbon/dist/ej2-ribbon.umd.min.js",
+        "@syncfusion/ej2-notifications": "syncfusion:ej2-notifications/dist/ej2-notifications.umd.min.js"
+    }
+});
+
+System.import('index.ts').catch(console.error.bind(console)).then(function () {
+    document.getElementById('loader').style.display = "none";
+    document.getElementById('container').style.visibility = "visible";
+});

--- a/ej2-javascript/code-snippet/ribbon/backstagemenu-keytip/ts/index.html
+++ b/ej2-javascript/code-snippet/ribbon/backstagemenu-keytip/ts/index.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <script src="https://cdn.syncfusion.com/ej2/syncfusion-helper.js"></script>
+    <title>Essential JS 2 - Ribbon</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+    <meta name="description" content="Essential JS 2" />
+    <meta name="author" content="Syncfusion" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-base/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-buttons/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-popups/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-splitbuttons/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-inputs/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-lists/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-dropdowns/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-navigations/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-ribbon/styles/material.css" rel="stylesheet" />
+
+    <!--style reference from app-->
+    <link href="styles.css" rel="stylesheet">
+
+    <!--system js reference and configuration-->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/systemjs/0.19.38/system.js"></script>
+    <script src="systemjs.config.js"></script>
+</head>
+<body>
+    <div id='loader'>LOADING....</div>
+    <div id='container'>
+        <div id="ribbon"></div>
+    </div>
+</body>
+<script type="text/x-jsrender" id="homeContent">
+    <div id='home-wrapper' style="padding: 20px;">
+        <div id='new-section' class='new-wrapper'>
+            <div class='section-title'> New </div>
+            <div class='category_container'>
+                <div class='doc_category_image'></div> 
+                <span class='doc_category_text'> New document </span>
+            </div>
+        </div>
+        <div id='block-wrapper'><div class='section-title'> Recent </div>
+            <div class="section-content" style="padding: 12px 0px; cursor: pointer">
+                <table>
+                    <tbody>
+                        <tr>
+                            <td> <span class="doc_icon e-icons e-open-link"></span> </td>
+                            <td> 
+                                <span style="display: block; font-size: 14px"> Ribbon.docx </span>
+                                <span style="font-size: 12px"> EJ2 >> Components >> Navigations >> Ribbon >> default </span>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</script>
+<script type="text/x-jsrender" id="newContent">
+    <div id='new-content' style="padding: 20px;">
+        <div id='new-section' class='new-wrapper'>
+            <div class='section-title'> New </div>
+            <div class='category_container'>
+                <div class='doc_category_image'></div> 
+                <span class='doc_category_text'> New document </span>
+            </div>
+        </div>
+    </div>
+</script>
+<script type="text/x-jsrender" id="openContent">
+    <div style="padding: 20px;">
+        <div class="section-content" style="padding: 12px 0px; cursor: pointer">
+            <table>
+                <tbody>
+                    <tr>
+                        <td> <span class="doc_icon e-icons e-open-link"></span> </td>
+                        <td> 
+                            <span style="display: block; font-size: 14px"> Open in Desktop App </span>
+                            <span style="font-size: 12px"> Use the full functionality of Ribbon </span>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <div class="section-content" style="padding: 12px 0px cursor: pointer">
+            <table>
+                <tbody>
+                    <tr>
+                        <td> <span class="doc_icon e-icons e-protect-sheet"></span> </td>
+                        <td> 
+                            <span style="display: block; font-size: 14px"> Protect Document </span>
+                            <span style="font-size: 12px">To prevent accidental changes,
+                                this document has been set to open as view-only.</span>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</script>
+<style>
+    #container {
+        visibility: hidden;
+    }
+
+    #loader {
+        color: #008cff;
+        height: 40px;
+        left: 45%;
+        position: absolute;
+        top: 45%;
+        width: 30%;
+    }
+</style>
+</html>

--- a/ej2-javascript/code-snippet/ribbon/filemenu-keytip/index.js
+++ b/ej2-javascript/code-snippet/ribbon/filemenu-keytip/index.js
@@ -8,10 +8,12 @@ var tabs = [
           {
             items: [
               {
-                type: "Button",
-                buttonSettings: {
-                  content: "Paste",
-                  iconCss: "e-icons e-paste",
+                type: 'SplitButton',
+                allowedSizes: ej.ribbon.RibbonItemSize.Large,
+                splitButtonSettings: {
+                  content: 'Paste',
+                  iconCss: 'e-icons e-paste',
+                  items: [{ text: 'Keep Source Format' }, { text: 'Merge format' }, { text: 'Keep text only' }]
                 }
               },
             ],

--- a/ej2-javascript/code-snippet/ribbon/filemenu-keytip/index.js
+++ b/ej2-javascript/code-snippet/ribbon/filemenu-keytip/index.js
@@ -1,0 +1,61 @@
+var tabs = [
+  {
+    header: "Home",
+    groups: [
+      {
+        header: "Clipboard",
+        collections: [
+          {
+            items: [
+              {
+                type: "Button",
+                buttonSettings: {
+                  content: "Paste",
+                  iconCss: "e-icons e-paste",
+                }
+              },
+            ],
+          },
+          {
+            items: [
+              {
+                type: "Button",
+                buttonSettings: {
+                  content: "Cut",
+                  iconCss: "e-icons e-cut",
+                }
+              },
+              {
+                type: "Button",
+                buttonSettings: {
+                  content: "Copy",
+                  iconCss: "e-icons e-copy",
+                }
+              },
+            ],
+          }
+        ]
+      }
+    ]
+  }
+];
+
+var fileMenuItems = [
+    { text: "New", iconCss: "e-icons e-file-new", id: "new" },
+    { text: "Open", iconCss: "e-icons e-folder-open", id: "Open" },
+    { text: "Rename", iconCss: "e-icons e-rename", id: "rename" },
+    { text: "Save as", iconCss: "e-icons e-save", id: "save" }
+];
+
+var ribbon = new ej.ribbon.Ribbon({
+    tabs: tabs,
+    fileMenu: {
+        menuItems: fileMenuItems,
+        keyTip: "F",
+        visible: true
+    },
+    enableKeyTips: true
+});
+ribbon.appendTo("#ribbon");
+ribbon.ribbonKeyTipModule.showKeyTips();
+

--- a/ej2-javascript/code-snippet/ribbon/filemenu-keytip/index.ts
+++ b/ej2-javascript/code-snippet/ribbon/filemenu-keytip/index.ts
@@ -1,6 +1,6 @@
 
 
-import { Ribbon, RibbonTabModel, RibbonItemType, RibbonFileMenu, RibbonKeyTip } from "@syncfusion/ej2-ribbon";
+import { Ribbon, RibbonTabModel, RibbonItemType, RibbonItemSize, RibbonFileMenu, RibbonKeyTip } from "@syncfusion/ej2-ribbon";
 import { MenuItemModel } from "@syncfusion/ej2-navigations";
 
 Ribbon.Inject(RibbonFileMenu, RibbonKeyTip);
@@ -15,10 +15,12 @@ let tabs: RibbonTabModel[] = [
           {
             items: [
               {
-                type: RibbonItemType.Button,
-                buttonSettings: {
-                  content: "Paste",
-                  iconCss: "e-icons e-paste",
+                type: RibbonItemType.SplitButton,
+                allowedSizes: RibbonItemSize.Large,
+                splitButtonSettings: {
+                    content: 'Paste',
+                    iconCss: 'e-icons e-paste',
+                    items: [{ text: 'Keep Source Format' }, { text: 'Merge format' }, { text: 'Keep text only' }]
                 }
               },
             ],

--- a/ej2-javascript/code-snippet/ribbon/filemenu-keytip/index.ts
+++ b/ej2-javascript/code-snippet/ribbon/filemenu-keytip/index.ts
@@ -1,0 +1,68 @@
+
+
+import { Ribbon, RibbonTabModel, RibbonItemType, RibbonFileMenu, RibbonKeyTip } from "@syncfusion/ej2-ribbon";
+import { MenuItemModel } from "@syncfusion/ej2-navigations";
+
+Ribbon.Inject(RibbonFileMenu, RibbonKeyTip);
+
+let tabs: RibbonTabModel[] = [
+  {
+    header: "Home",
+    groups: [
+      {
+        header: "Clipboard",
+        collections: [
+          {
+            items: [
+              {
+                type: RibbonItemType.Button,
+                buttonSettings: {
+                  content: "Paste",
+                  iconCss: "e-icons e-paste",
+                }
+              },
+            ],
+          },
+          {
+            items: [
+              {
+                type: RibbonItemType.Button,
+                buttonSettings: {
+                  content: "Cut",
+                  iconCss: "e-icons e-cut",
+                }
+              },
+              {
+                type: RibbonItemType.Button,
+                buttonSettings: {
+                  content: "Copy",
+                  iconCss: "e-icons e-copy",
+                }
+              },
+            ],
+          }
+        ]
+      }
+    ]
+  }
+];
+
+let fileMenuItems: MenuItemModel[] = [
+    { text: "New", iconCss: "e-icons e-file-new", id: "new" },
+    { text: "Open", iconCss: "e-icons e-folder-open", id: "Open" },
+    { text: "Rename", iconCss: "e-icons e-rename", id: "rename" },
+    { text: "Save as", iconCss: "e-icons e-save", id: "save" }
+];
+
+let ribbon: Ribbon = new Ribbon({
+    tabs: tabs,
+    fileMenu: {
+        menuItems: fileMenuItems,
+        keyTip: "F",
+        visible: true
+    },
+    enableKeyTips: true
+});
+ribbon.appendTo("#ribbon");
+ribbon.ribbonKeyTipModule.showKeyTips();
+

--- a/ej2-javascript/code-snippet/ribbon/filemenu-keytip/js/index.html
+++ b/ej2-javascript/code-snippet/ribbon/filemenu-keytip/js/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html><html lang="en"><head>
+            <script src="https://cdn.syncfusion.com/ej2/syncfusion-helper.js"></script>
+    <title>Essential JS 2 - Ribbon</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="description" content="Essential JS 2">
+    <meta name="author" content="Syncfusion">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-base/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-buttons/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-popups/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-splitbuttons/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-inputs/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-lists/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-dropdowns/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-navigations/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-ribbon/styles/material.css" rel="stylesheet">
+
+    <!--system js reference and configuration-->
+    
+    
+<script src="https://cdn.syncfusion.com/ej2/20.3.56/dist/ej2.min.js" type="text/javascript"></script>
+</head>
+<body>
+    
+    <div id="container">
+        <div id="ribbon"></div>
+    </div>
+
+
+
+<script>
+var ele = document.getElementById('container');
+if(ele) {
+    ele.style.visibility = "visible";
+ }   
+        </script>
+<script src="index.js" type="text/javascript"></script>
+</body></html>

--- a/ej2-javascript/code-snippet/ribbon/filemenu-keytip/systemjs.config.js
+++ b/ej2-javascript/code-snippet/ribbon/filemenu-keytip/systemjs.config.js
@@ -1,0 +1,35 @@
+System.config({
+    transpiler: "typescript",
+    typescriptOptions: {
+        compilerOptions: {
+            target: "umd",
+            module: "commonjs",
+            moduleResolution: "node",
+            emitDecoratorMetadata: true,
+            experimentalDecorators: true
+        }
+    },
+    paths: {
+        "syncfusion:": "https://cdn.syncfusion.com/ej2/20.3.56/"
+    },
+    map: {
+        main: "index.ts",
+        typescript: "https://unpkg.com/typescript@2.2.2/lib/typescript.js",
+        "@syncfusion/ej2-base": "syncfusion:ej2-base/dist/ej2-base.umd.min.js",
+        "@syncfusion/ej2-data": "syncfusion:ej2-data/dist/ej2-data.umd.min.js",
+        "@syncfusion/ej2-buttons": "syncfusion:ej2-buttons/dist/ej2-buttons.umd.min.js",
+        "@syncfusion/ej2-splitbuttons": "syncfusion:ej2-splitbuttons/dist/ej2-splitbuttons.umd.min.js",
+        "@syncfusion/ej2-popups": "syncfusion:ej2-popups/dist/ej2-popups.umd.min.js",
+        "@syncfusion/ej2-inputs": "syncfusion:ej2-inputs/dist/ej2-inputs.umd.min.js",
+        "@syncfusion/ej2-lists": "syncfusion:ej2-lists/dist/ej2-lists.umd.min.js",
+        "@syncfusion/ej2-dropdowns": "syncfusion:ej2-dropdowns/dist/ej2-dropdowns.umd.min.js",
+        "@syncfusion/ej2-navigations": "syncfusion:ej2-navigations/dist/ej2-navigations.umd.min.js",
+        "@syncfusion/ej2-ribbon": "syncfusion:ej2-ribbon/dist/ej2-ribbon.umd.min.js",
+        "@syncfusion/ej2-notifications": "syncfusion:ej2-notifications/dist/ej2-notifications.umd.min.js"
+    }
+});
+
+System.import('index.ts').catch(console.error.bind(console)).then(function () {
+    document.getElementById('loader').style.display = "none";
+    document.getElementById('container').style.visibility = "visible";
+});

--- a/ej2-javascript/code-snippet/ribbon/filemenu-keytip/ts/index.html
+++ b/ej2-javascript/code-snippet/ribbon/filemenu-keytip/ts/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+            <script src="https://cdn.syncfusion.com/ej2/syncfusion-helper.js"></script>
+    <title>Essential JS 2 - Ribbon</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+    <meta name="description" content="Essential JS 2" />
+    <meta name="author" content="Syncfusion" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-base/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-buttons/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-popups/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-splitbuttons/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-inputs/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-lists/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-dropdowns/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-navigations/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-ribbon/styles/material.css" rel="stylesheet" />
+
+    <!--system js reference and configuration-->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/systemjs/0.19.38/system.js"></script>
+    <script src="systemjs.config.js"></script>
+</head>
+<body>
+    <div id='loader'>LOADING....</div>
+    <div id='container'>
+        <div id="ribbon"></div>
+    </div>
+</body>
+<style>
+    #container {
+        visibility: hidden;
+    }
+
+    #loader {
+        color: #008cff;
+        height: 40px;
+        left: 45%;
+        position: absolute;
+        top: 45%;
+        width: 30%;
+    }
+</style>
+</html>

--- a/ej2-javascript/code-snippet/ribbon/item-keytip/index.js
+++ b/ej2-javascript/code-snippet/ribbon/item-keytip/index.js
@@ -1,0 +1,139 @@
+var fontStyle = ['Algerian', 'Arial', 'Calibri', 'Cambria', 'Cambria Math', 'Candara', 'Courier New', 'Georgia', 'Impact', 'Segoe Print', 'Segoe Script', 'Segoe UI', 'Symbol', 'Times New Roman', 'Verdana', 'Windings'
+];
+var fontSize = ['8', '9', '10', '11', '12', '14', '16', '18', '20', '22', '24', '26', '28', '36', '48', '72', '96'];
+var tabs = [{
+    header: "Home",
+    keyTip: 'H',
+    groups: [{
+        header: "Clipboard",
+        groupIconCss: 'e-icons e-paste',
+        showLauncherIcon:true,
+        launcherIconKeyTip: 'V1',
+        keyTip: 'CD',
+        collections: [{
+            items: [{
+                type: 'SplitButton',
+                allowedSizes: ej.ribbon.RibbonItemSize.Large,
+                keyTip: 'PA',
+                ribbonTooltipSettings: {
+                    title: 'Paste',
+                    cssClass:'custom-tooltip',
+                    iconCss: 'e-icons e-paste',
+                    content: 'Paste content here.</br> Add content on the clipboard to your document.'
+                },
+                splitButtonSettings: {
+                    content: 'Paste',
+                    iconCss: 'e-icons e-paste',
+                    items: [{ text: 'Keep Source Format' }, { text: 'Merge format' }, { text: 'Keep text only' }]
+                }
+            }]
+        }, {
+            items: [{
+                type: 'Button',
+                keyTip: 'CU',
+                buttonSettings: {
+                    content: 'cut',
+                    iconCss: 'e-icons e-cut'
+                }
+            }, {
+                type: 'Button',
+                keyTip: 'CO',
+                buttonSettings: {
+                    content: 'copy',
+                    iconCss: 'e-icons e-copy'
+                }
+            }, {
+                type: 'GroupButton',
+                keyTip: 'GB',
+                groupButtonSettings: {
+                    selection: ej.ribbon.RibbonGroupButtonSelection.Single,
+                    items: [{
+                        iconCss: 'e-icons e-table',
+                        content: 'table',
+                        keyTip: 'T1',
+                        selected: true
+                    },
+                    {
+                        iconCss: 'e-icons e-image',
+                        content: 'picture',
+                        keyTip: 'P1'
+                    },
+                    {
+                        iconCss: 'e-icons e-menu',
+                        content: 'menu',
+                        keyTip: 'M1'
+                    }]
+                }
+            }]
+        },]
+    }, {
+        header: "Font",
+        orientation: 'Row',
+        groupIconCss: 'e-icons e-bold',
+        enableGroupOverflow: true,
+        showLauncherIcon:true,
+        keyTip: 'FB',
+        launcherIconKeyTip: 'V2',
+        cssClass: 'font-group',
+        collections: [{
+            items: [{
+                type: 'ComboBox',
+                keyTip: 'O',
+                comboBoxSettings: {
+                    dataSource: fontStyle,
+                    index: 2,
+                    allowFiltering: true,
+                    width: '150px'
+                }
+            }, {
+                type: 'ComboBox',
+                comboBoxSettings: {
+                    dataSource: fontSize,
+                    index: 4,
+                    width: '65px'
+                }
+            }]
+        }, {
+            items: [{
+                type: 'Button',
+                allowedSizes: ej.ribbon.RibbonItemSize.Small,
+                keyTip: 'B',
+                buttonSettings: {
+                    content: 'Bold',
+                    iconCss: 'e-icons e-bold'
+                }
+            }, {
+                type: 'Button',
+                allowedSizes: ej.ribbon.RibbonItemSize.Small,
+                keyTip: 'I',
+                buttonSettings: {
+                    content: 'Italic',
+                    iconCss: 'e-icons e-italic'
+                }
+            }, {
+                type: 'Button',
+                allowedSizes: ej.ribbon.RibbonItemSize.Small,
+                keyTip: 'U',
+                buttonSettings: {
+                    content: 'UnderLine',
+                    iconCss: 'e-icons e-underline'
+                }
+            }, {
+                type: 'ColorPicker',
+                keyTip: 'CP',
+                colorPickerSettings: {
+                    value: '#123456'
+                }
+            }
+            ]
+        }]
+    }]
+}];
+
+var ribbon = new ej.ribbon.Ribbon({
+  tabs: tabs,
+  enableKeyTips: true
+});
+ribbon.appendTo("#ribbon");
+
+ribbon.ribbonKeyTipModule.showKeyTips('H');

--- a/ej2-javascript/code-snippet/ribbon/item-keytip/index.js
+++ b/ej2-javascript/code-snippet/ribbon/item-keytip/index.js
@@ -116,7 +116,7 @@ var tabs = [{
     collections: [{
       items: [{
         type: 'Gallery',
-        keyTip: 'G',
+        keyTip: 'GY',
         gallerySettings: {
           itemCount: 3,
           groups: [{

--- a/ej2-javascript/code-snippet/ribbon/item-keytip/index.js
+++ b/ej2-javascript/code-snippet/ribbon/item-keytip/index.js
@@ -2,132 +2,191 @@ var fontStyle = ['Algerian', 'Arial', 'Calibri', 'Cambria', 'Cambria Math', 'Can
 ];
 var fontSize = ['8', '9', '10', '11', '12', '14', '16', '18', '20', '22', '24', '26', '28', '36', '48', '72', '96'];
 var tabs = [{
-    header: "Home",
-    keyTip: 'H',
-    groups: [{
-        header: "Clipboard",
-        groupIconCss: 'e-icons e-paste',
-        showLauncherIcon:true,
-        launcherIconKeyTip: 'V1',
-        keyTip: 'CD',
-        collections: [{
-            items: [{
-                type: 'SplitButton',
-                allowedSizes: ej.ribbon.RibbonItemSize.Large,
-                keyTip: 'PA',
-                ribbonTooltipSettings: {
-                    title: 'Paste',
-                    cssClass:'custom-tooltip',
-                    iconCss: 'e-icons e-paste',
-                    content: 'Paste content here.</br> Add content on the clipboard to your document.'
-                },
-                splitButtonSettings: {
-                    content: 'Paste',
-                    iconCss: 'e-icons e-paste',
-                    items: [{ text: 'Keep Source Format' }, { text: 'Merge format' }, { text: 'Keep text only' }]
-                }
-            }]
-        }, {
-            items: [{
-                type: 'Button',
-                keyTip: 'CU',
-                buttonSettings: {
-                    content: 'cut',
-                    iconCss: 'e-icons e-cut'
-                }
-            }, {
-                type: 'Button',
-                keyTip: 'CO',
-                buttonSettings: {
-                    content: 'copy',
-                    iconCss: 'e-icons e-copy'
-                }
-            }, {
-                type: 'GroupButton',
-                keyTip: 'GB',
-                groupButtonSettings: {
-                    selection: ej.ribbon.RibbonGroupButtonSelection.Single,
-                    items: [{
-                        iconCss: 'e-icons e-table',
-                        content: 'table',
-                        keyTip: 'T1',
-                        selected: true
-                    },
-                    {
-                        iconCss: 'e-icons e-image',
-                        content: 'picture',
-                        keyTip: 'P1'
-                    },
-                    {
-                        iconCss: 'e-icons e-menu',
-                        content: 'menu',
-                        keyTip: 'M1'
-                    }]
-                }
-            }]
-        },]
+  header: "Home",
+  keyTip: 'H',
+  groups: [{
+    header: "Clipboard",
+    groupIconCss: 'e-icons e-paste',
+    keyTip: 'CD',
+    collections: [{
+      items: [{
+        type: 'SplitButton',
+        allowedSizes: ej.ribbon.RibbonItemSize.Large,
+        keyTip: 'PA',
+        ribbonTooltipSettings: {
+          title: 'Paste',
+          cssClass: 'custom-tooltip',
+          iconCss: 'e-icons e-paste',
+          content: 'Paste content here.</br> Add content on the clipboard to your document.'
+        },
+        splitButtonSettings: {
+          content: 'Paste',
+          iconCss: 'e-icons e-paste',
+          items: [{ text: 'Keep Source Format' }, { text: 'Merge format' }, { text: 'Keep text only' }]
+        }
+      }]
     }, {
-        header: "Font",
-        orientation: 'Row',
-        groupIconCss: 'e-icons e-bold',
-        enableGroupOverflow: true,
-        showLauncherIcon:true,
-        keyTip: 'FB',
-        launcherIconKeyTip: 'V2',
-        cssClass: 'font-group',
-        collections: [{
-            items: [{
-                type: 'ComboBox',
-                keyTip: 'O',
-                comboBoxSettings: {
-                    dataSource: fontStyle,
-                    index: 2,
-                    allowFiltering: true,
-                    width: '150px'
-                }
-            }, {
-                type: 'ComboBox',
-                comboBoxSettings: {
-                    dataSource: fontSize,
-                    index: 4,
-                    width: '65px'
-                }
-            }]
-        }, {
-            items: [{
-                type: 'Button',
-                allowedSizes: ej.ribbon.RibbonItemSize.Small,
-                keyTip: 'B',
-                buttonSettings: {
-                    content: 'Bold',
-                    iconCss: 'e-icons e-bold'
-                }
-            }, {
-                type: 'Button',
-                allowedSizes: ej.ribbon.RibbonItemSize.Small,
-                keyTip: 'I',
-                buttonSettings: {
-                    content: 'Italic',
-                    iconCss: 'e-icons e-italic'
-                }
-            }, {
-                type: 'Button',
-                allowedSizes: ej.ribbon.RibbonItemSize.Small,
-                keyTip: 'U',
-                buttonSettings: {
-                    content: 'UnderLine',
-                    iconCss: 'e-icons e-underline'
-                }
-            }, {
-                type: 'ColorPicker',
-                keyTip: 'CP',
-                colorPickerSettings: {
-                    value: '#123456'
-                }
-            }
-            ]
-        }]
+      items: [{
+        type: 'Button',
+        keyTip: 'CU',
+        buttonSettings: {
+          content: 'Cut',
+          iconCss: 'e-icons e-cut'
+        }
+      }, {
+        type: 'Button',
+        keyTip: 'CO',
+        buttonSettings: {
+          content: 'Copy',
+          iconCss: 'e-icons e-copy'
+        }
+      }, {
+        type: 'Button',
+        keyTip: 'CS',
+        buttonSettings: {
+          content: 'Format Painter',
+          iconCss: 'e-icons e-format-painter'
+        }
+      }]
+    },]
+  }, {
+    header: "Font",
+    orientation: 'Row',
+    groupIconCss: 'e-icons e-bold',
+    enableGroupOverflow: true,
+    keyTip: 'FB',
+    cssClass: 'font-group',
+    collections: [{
+      items: [{
+        type: 'ComboBox',
+        keyTip: 'O',
+        comboBoxSettings: {
+          dataSource: fontStyle,
+          index: 2,
+          allowFiltering: true,
+          width: '150px'
+        }
+      }, {
+        type: 'ComboBox',
+        comboBoxSettings: {
+          dataSource: fontSize,
+          index: 4,
+          width: '65px'
+        }
+      }]
+    }, {
+      items: [{
+        type: 'GroupButton',
+        keyTip: 'GB',
+        groupButtonSettings: {
+          selection: ej.ribbon.RibbonGroupButtonSelection.Single,
+          items: [{
+            iconCss: 'e-icons e-bold',
+            keyTip: '1',
+            selected: true
+          },
+          {
+            iconCss: 'e-icons e-italic',
+            keyTip: '2'
+          },
+          {
+            iconCss: 'e-icons e-underline',
+            keyTip: '3'
+          },
+          {
+            iconCss: 'e-icons e-strikethrough',
+            keyTip: '4'
+          },
+          {
+            iconCss: 'e-icons e-change-case',
+            keyTip: '5'
+          }]
+        }
+      }, {
+        type: 'ColorPicker',
+        keyTip: 'CP',
+        colorPickerSettings: {
+          value: '#123456'
+        }
+      }]
     }]
+  }, {
+    header: "Gallery",
+    groupIconCss: 'e-icons e-paste',
+    collections: [{
+      items: [{
+        type: 'Gallery',
+        keyTip: 'G',
+        gallerySettings: {
+          itemCount: 3,
+          groups: [{
+            itemWidth: '100',
+            header: 'Styles',
+            items: [{
+              content: 'Normal'
+            }, {
+              content: 'No Spacing'
+            }, {
+              content: 'Heading 1'
+            }, {
+              content: 'Heading 2'
+            }, {
+              content: 'Heading 3'
+            }, {
+              content: 'Heading 4'
+            }, {
+              content: 'Heading 5'
+            }]
+          }]
+        }
+      }]
+    }]
+  }, {
+    header: 'Tables',
+    groupIconCss: 'e-icons e-table',
+    collections: [{
+      items: [{
+        type: 'DropDown',
+        keyTip: 'T',
+        allowedSizes: ej.ribbon.RibbonItemSize.Large,
+        dropDownSettings: {
+          content: 'Table',
+          iconCss: 'e-icons e-table',
+          items: [
+            { text: 'Insert Table' }, { text: 'Draw Table' },
+            { text: 'Convert Table' }, { text: 'Excel SpreadSheet' }
+          ]
+        }
+      }]
+    }]
+  }, {
+    header: 'Show',
+    groupIconCss: 'e-icons e-copy',
+    collections: [{
+      items: [{
+        type: 'CheckBox',
+        keyTip: 'R1',
+        checkBoxSettings: {
+          label: 'Ruler',
+          checked: false
+        }
+      }, {
+        type: 'CheckBox',
+        keyTip: 'R2',
+        checkBoxSettings: {
+          label: 'Gridlines',
+          checked: false
+        }
+      }, {
+        type: 'CheckBox',
+        keyTip: 'R3',
+        checkBoxSettings: {
+          label: 'Navigation Pane',
+          checked: true
+        }
+      }]
+    }]
+  }]
 }];
 
 var ribbon = new ej.ribbon.Ribbon({

--- a/ej2-javascript/code-snippet/ribbon/item-keytip/index.ts
+++ b/ej2-javascript/code-snippet/ribbon/item-keytip/index.ts
@@ -1,144 +1,209 @@
 
 
-import { Ribbon, RibbonItemSize, RibbonItemType, RibbonTabModel, RibbonGroupButtonSelection, RibbonKeyTip } from '@syncfusion/ej2-ribbon';
+import { Ribbon, RibbonItemSize, RibbonItemType, RibbonTabModel, RibbonGroupButtonSelection, RibbonKeyTip, RibbonGallery } from '@syncfusion/ej2-ribbon';
 
-Ribbon.Inject(RibbonKeyTip);
+Ribbon.Inject(RibbonKeyTip, RibbonGallery);
 
 let fontStyle: string[] = ['Algerian', 'Arial', 'Calibri', 'Cambria', 'Cambria Math', 'Candara', 'Courier New', 'Georgia', 'Impact', 'Segoe Print', 'Segoe Script', 'Segoe UI', 'Symbol', 'Times New Roman', 'Verdana', 'Windings'
 ];
 let fontSize: string[] = ['8', '9', '10', '11', '12', '14', '16', '18', '20', '22', '24', '26', '28', '36', '48', '72', '96'];
 let tabs: RibbonTabModel[] = [{
-    header: "Home",
-    keyTip: 'H',
-    groups: [{
-        header: "Clipboard",
-        groupIconCss: 'e-icons e-paste',
-        showLauncherIcon:true,
-        launcherIconKeyTip: 'V1',
-        keyTip: 'CD',
-        collections: [{
-            items: [{
-                type: RibbonItemType.SplitButton,
-                allowedSizes: RibbonItemSize.Large,
-                keyTip: 'PA',
-                ribbonTooltipSettings: {
-                    title: 'Paste',
-                    cssClass:'custom-tooltip',
-                    iconCss: 'e-icons e-paste',
-                    content: 'Paste content here.</br> Add content on the clipboard to your document.'
-                },
-                splitButtonSettings: {
-                    content: 'Paste',
-                    iconCss: 'e-icons e-paste',
-                    items: [{ text: 'Keep Source Format' }, { text: 'Merge format' }, { text: 'Keep text only' }]
-                }
-            }]
-        }, {
-            items: [{
-                type: RibbonItemType.Button,
-                keyTip: 'CU',
-                buttonSettings: {
-                    content: 'cut',
-                    iconCss: 'e-icons e-cut'
-                }
-            }, {
-                type: RibbonItemType.Button,
-                keyTip: 'CO',
-                buttonSettings: {
-                    content: 'copy',
-                    iconCss: 'e-icons e-copy'
-                }
-            }, {
-                type: RibbonItemType.GroupButton,
-                keyTip: 'GB',
-                groupButtonSettings: {
-                    selection: RibbonGroupButtonSelection.Single,
-                    items: [{
-                        iconCss: 'e-icons e-table',
-                        content: 'table',
-                        keyTip: 'T1',
-                        selected: true
-                    },
-                    {
-                        iconCss: 'e-icons e-image',
-                        content: 'picture',
-                        keyTip: 'P1'
-                    },
-                    {
-                        iconCss: 'e-icons e-menu',
-                        content: 'menu',
-                        keyTip: 'M1'
-                    }]
-                }
-            }]
-        },]
+  header: "Home",
+  keyTip: 'H',
+  groups: [{
+    header: "Clipboard",
+    groupIconCss: 'e-icons e-paste',
+    keyTip: 'CD',
+    collections: [{
+      items: [{
+        type: RibbonItemType.SplitButton,
+        allowedSizes: RibbonItemSize.Large,
+        keyTip: 'PA',
+        ribbonTooltipSettings: {
+          title: 'Paste',
+          cssClass: 'custom-tooltip',
+          iconCss: 'e-icons e-paste',
+          content: 'Paste content here.</br> Add content on the clipboard to your document.'
+        },
+        splitButtonSettings: {
+          content: 'Paste',
+          iconCss: 'e-icons e-paste',
+          items: [{ text: 'Keep Source Format' }, { text: 'Merge format' }, { text: 'Keep text only' }]
+        }
+      }]
     }, {
-        header: "Font",
-        orientation: 'Row',
-        groupIconCss: 'e-icons e-bold',
-        enableGroupOverflow: true,
-        showLauncherIcon:true,
-        keyTip: 'FB',
-        launcherIconKeyTip: 'V2',
-        cssClass: 'font-group',
-        collections: [{
-            items: [{
-                type: RibbonItemType.ComboBox,
-                keyTip: 'O',
-                comboBoxSettings: {
-                    dataSource: fontStyle,
-                    index: 2,
-                    allowFiltering: true,
-                    width: '150px'
-                }
-            }, {
-                type: RibbonItemType.ComboBox,
-                comboBoxSettings: {
-                    dataSource: fontSize,
-                    index: 4,
-                    width: '65px'
-                }
-            }]
-        }, {
-            items: [{
-                type: RibbonItemType.Button,
-                allowedSizes: RibbonItemSize.Small,
-                keyTip: 'B',
-                buttonSettings: {
-                    content: 'Bold',
-                    iconCss: 'e-icons e-bold'
-                }
-            }, {
-                type: RibbonItemType.Button,
-                allowedSizes: RibbonItemSize.Small,
-                keyTip: 'I',
-                buttonSettings: {
-                    content: 'Italic',
-                    iconCss: 'e-icons e-italic'
-                }
-            }, {
-                type: RibbonItemType.Button,
-                allowedSizes: RibbonItemSize.Small,
-                keyTip: 'U',
-                buttonSettings: {
-                    content: 'UnderLine',
-                    iconCss: 'e-icons e-underline'
-                }
-            }, {
-                type: RibbonItemType.ColorPicker,
-                keyTip: 'CP',
-                colorPickerSettings: {
-                    value: '#123456'
-                }
-            }
-            ]
-        }]
+      items: [{
+        type: RibbonItemType.Button,
+        keyTip: 'CU',
+        buttonSettings: {
+          content: 'cut',
+          iconCss: 'e-icons e-cut'
+        }
+      }, {
+        type: RibbonItemType.Button,
+        keyTip: 'CO',
+        buttonSettings: {
+          content: 'copy',
+          iconCss: 'e-icons e-copy'
+        }
+      }, {
+        type: RibbonItemType.Button,
+        keyTip: 'CS',
+        buttonSettings: {
+          content: 'Format Painter',
+          iconCss: 'e-icons e-format-painter'
+        }
+      }]
+    },]
+  }, {
+    header: "Font",
+    orientation: 'Row',
+    groupIconCss: 'e-icons e-bold',
+    enableGroupOverflow: true,
+    keyTip: 'FB',
+    cssClass: 'font-group',
+    collections: [{
+      items: [{
+        type: RibbonItemType.ComboBox,
+        keyTip: 'O1',
+        comboBoxSettings: {
+          dataSource: fontStyle,
+          index: 2,
+          allowFiltering: true,
+          width: '150px'
+        }
+      }, {
+        type: RibbonItemType.ComboBox,
+        keyTip: 'O2',
+        comboBoxSettings: {
+          dataSource: fontSize,
+          index: 4,
+          width: '65px'
+        }
+      }]
+    }, {
+      items: [{
+        type: RibbonItemType.GroupButton,
+        keyTip: 'GB',
+        groupButtonSettings: {
+          selection: RibbonGroupButtonSelection.Single,
+          items: [{
+            iconCss: 'e-icons e-bold',
+            keyTip: '1',
+            selected: true
+          },
+          {
+            iconCss: 'e-icons e-italic',
+            keyTip: '2'
+          },
+          {
+            iconCss: 'e-icons e-underline',
+            keyTip: '3'
+          },
+          {
+            iconCss: 'e-icons e-strikethrough',
+            keyTip: '4'
+          },
+          {
+            iconCss: 'e-icons e-change-case',
+            keyTip: '5'
+          }]
+        }
+      }, {
+        type: RibbonItemType.ColorPicker,
+        keyTip: 'CP',
+        colorPickerSettings: {
+          value: '#123456'
+        }
+      }
+      ]
     }]
+  },
+  {
+    header: "Gallery",
+    showLauncherIcon: true,
+    groupIconCss: 'e-icons e-paste',
+    collections: [{
+      items: [{
+        type: RibbonItemType.Gallery,
+        keyTip: 'G',
+        gallerySettings: {
+          itemCount: 3,
+          groups: [{
+            itemWidth: '100',
+            header: 'Styles',
+            items: [{
+              content: 'Normal'
+            }, {
+              content: 'No Spacing'
+            }, {
+              content: 'Heading 1'
+            }, {
+              content: 'Heading 2'
+            }, {
+              content: 'Heading 3'
+            }, {
+              content: 'Heading 4'
+            }, {
+              content: 'Heading 5'
+            }]
+          }]
+        }
+      }]
+    }]
+  },
+  {
+    header: 'Tables',
+    groupIconCss: 'e-icons e-table',
+    collections: [{
+      items: [{
+        type: RibbonItemType.DropDown,
+        keyTip: 'T',
+        allowedSizes: RibbonItemSize.Large,
+        dropDownSettings: {
+          content: 'Table',
+          iconCss: 'e-icons e-table',
+          items: [
+            { text: 'Insert Table' }, { text: 'Draw Table' },
+            { text: 'Convert Table' }, { text: 'Excel SpreadSheet' }
+          ]
+        }
+      }]
+    }]
+  },
+  {
+    header: 'Show',
+    groupIconCss: 'e-icons e-copy',
+    collections: [{
+      items: [{
+        type: RibbonItemType.CheckBox,
+        keyTip: 'R1',
+        checkBoxSettings: {
+          label: 'Ruler',
+          checked: false
+        }
+      }, {
+        type: RibbonItemType.CheckBox,
+        keyTip: 'R2',
+        checkBoxSettings: {
+          label: 'Gridlines',
+          checked: false
+        }
+      }, {
+        type: RibbonItemType.CheckBox,
+        keyTip: 'R3',
+        checkBoxSettings: {
+          label: 'Navigation Pane',
+          checked: true
+        }
+      }]
+    }]
+  }]
 }];
 
 let ribbon: Ribbon = new Ribbon({
-    tabs: tabs,
-    enableKeyTips: true
+  tabs: tabs,
+  enableKeyTips: true
 });
 ribbon.appendTo("#ribbon");
 

--- a/ej2-javascript/code-snippet/ribbon/item-keytip/index.ts
+++ b/ej2-javascript/code-snippet/ribbon/item-keytip/index.ts
@@ -126,7 +126,7 @@ let tabs: RibbonTabModel[] = [{
     collections: [{
       items: [{
         type: RibbonItemType.Gallery,
-        keyTip: 'G',
+        keyTip: 'GY',
         gallerySettings: {
           itemCount: 3,
           groups: [{

--- a/ej2-javascript/code-snippet/ribbon/item-keytip/index.ts
+++ b/ej2-javascript/code-snippet/ribbon/item-keytip/index.ts
@@ -1,0 +1,145 @@
+
+
+import { Ribbon, RibbonItemSize, RibbonItemType, RibbonTabModel, RibbonGroupButtonSelection, RibbonKeyTip } from '@syncfusion/ej2-ribbon';
+
+Ribbon.Inject(RibbonKeyTip);
+
+let fontStyle: string[] = ['Algerian', 'Arial', 'Calibri', 'Cambria', 'Cambria Math', 'Candara', 'Courier New', 'Georgia', 'Impact', 'Segoe Print', 'Segoe Script', 'Segoe UI', 'Symbol', 'Times New Roman', 'Verdana', 'Windings'
+];
+let fontSize: string[] = ['8', '9', '10', '11', '12', '14', '16', '18', '20', '22', '24', '26', '28', '36', '48', '72', '96'];
+let tabs: RibbonTabModel[] = [{
+    header: "Home",
+    keyTip: 'H',
+    groups: [{
+        header: "Clipboard",
+        groupIconCss: 'e-icons e-paste',
+        showLauncherIcon:true,
+        launcherIconKeyTip: 'V1',
+        keyTip: 'CD',
+        collections: [{
+            items: [{
+                type: RibbonItemType.SplitButton,
+                allowedSizes: RibbonItemSize.Large,
+                keyTip: 'PA',
+                ribbonTooltipSettings: {
+                    title: 'Paste',
+                    cssClass:'custom-tooltip',
+                    iconCss: 'e-icons e-paste',
+                    content: 'Paste content here.</br> Add content on the clipboard to your document.'
+                },
+                splitButtonSettings: {
+                    content: 'Paste',
+                    iconCss: 'e-icons e-paste',
+                    items: [{ text: 'Keep Source Format' }, { text: 'Merge format' }, { text: 'Keep text only' }]
+                }
+            }]
+        }, {
+            items: [{
+                type: RibbonItemType.Button,
+                keyTip: 'CU',
+                buttonSettings: {
+                    content: 'cut',
+                    iconCss: 'e-icons e-cut'
+                }
+            }, {
+                type: RibbonItemType.Button,
+                keyTip: 'CO',
+                buttonSettings: {
+                    content: 'copy',
+                    iconCss: 'e-icons e-copy'
+                }
+            }, {
+                type: RibbonItemType.GroupButton,
+                keyTip: 'GB',
+                groupButtonSettings: {
+                    selection: RibbonGroupButtonSelection.Single,
+                    items: [{
+                        iconCss: 'e-icons e-table',
+                        content: 'table',
+                        keyTip: 'T1',
+                        selected: true
+                    },
+                    {
+                        iconCss: 'e-icons e-image',
+                        content: 'picture',
+                        keyTip: 'P1'
+                    },
+                    {
+                        iconCss: 'e-icons e-menu',
+                        content: 'menu',
+                        keyTip: 'M1'
+                    }]
+                }
+            }]
+        },]
+    }, {
+        header: "Font",
+        orientation: 'Row',
+        groupIconCss: 'e-icons e-bold',
+        enableGroupOverflow: true,
+        showLauncherIcon:true,
+        keyTip: 'FB',
+        launcherIconKeyTip: 'V2',
+        cssClass: 'font-group',
+        collections: [{
+            items: [{
+                type: RibbonItemType.ComboBox,
+                keyTip: 'O',
+                comboBoxSettings: {
+                    dataSource: fontStyle,
+                    index: 2,
+                    allowFiltering: true,
+                    width: '150px'
+                }
+            }, {
+                type: RibbonItemType.ComboBox,
+                comboBoxSettings: {
+                    dataSource: fontSize,
+                    index: 4,
+                    width: '65px'
+                }
+            }]
+        }, {
+            items: [{
+                type: RibbonItemType.Button,
+                allowedSizes: RibbonItemSize.Small,
+                keyTip: 'B',
+                buttonSettings: {
+                    content: 'Bold',
+                    iconCss: 'e-icons e-bold'
+                }
+            }, {
+                type: RibbonItemType.Button,
+                allowedSizes: RibbonItemSize.Small,
+                keyTip: 'I',
+                buttonSettings: {
+                    content: 'Italic',
+                    iconCss: 'e-icons e-italic'
+                }
+            }, {
+                type: RibbonItemType.Button,
+                allowedSizes: RibbonItemSize.Small,
+                keyTip: 'U',
+                buttonSettings: {
+                    content: 'UnderLine',
+                    iconCss: 'e-icons e-underline'
+                }
+            }, {
+                type: RibbonItemType.ColorPicker,
+                keyTip: 'CP',
+                colorPickerSettings: {
+                    value: '#123456'
+                }
+            }
+            ]
+        }]
+    }]
+}];
+
+let ribbon: Ribbon = new Ribbon({
+    tabs: tabs,
+    enableKeyTips: true
+});
+ribbon.appendTo("#ribbon");
+
+ribbon.ribbonKeyTipModule.showKeyTips('H');

--- a/ej2-javascript/code-snippet/ribbon/item-keytip/js/index.html
+++ b/ej2-javascript/code-snippet/ribbon/item-keytip/js/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html><html lang="en"><head>
+            <script src="https://cdn.syncfusion.com/ej2/syncfusion-helper.js"></script>
+    <title>Essential JS 2 - Ribbon</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="description" content="Essential JS 2">
+    <meta name="author" content="Syncfusion">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-base/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-buttons/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-popups/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-splitbuttons/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-inputs/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-lists/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-dropdowns/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-navigations/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-ribbon/styles/material.css" rel="stylesheet">
+
+    <!--system js reference and configuration-->
+    
+    
+<script src="https://cdn.syncfusion.com/ej2/20.3.56/dist/ej2.min.js" type="text/javascript"></script>
+</head>
+<body>
+    
+    <div id="container">
+        <div id="ribbon"></div>
+    </div>
+
+
+
+<script>
+var ele = document.getElementById('container');
+if(ele) {
+    ele.style.visibility = "visible";
+ }   
+        </script>
+<script src="index.js" type="text/javascript"></script>
+</body></html>

--- a/ej2-javascript/code-snippet/ribbon/item-keytip/styles.css
+++ b/ej2-javascript/code-snippet/ribbon/item-keytip/styles.css
@@ -1,0 +1,3 @@
+.custom-tooltip.e-paste{
+  font-size: 50px;
+}

--- a/ej2-javascript/code-snippet/ribbon/item-keytip/systemjs.config.js
+++ b/ej2-javascript/code-snippet/ribbon/item-keytip/systemjs.config.js
@@ -1,0 +1,35 @@
+System.config({
+    transpiler: "typescript",
+    typescriptOptions: {
+        compilerOptions: {
+            target: "umd",
+            module: "commonjs",
+            moduleResolution: "node",
+            emitDecoratorMetadata: true,
+            experimentalDecorators: true
+        }
+    },
+    paths: {
+        "syncfusion:": "https://cdn.syncfusion.com/ej2/20.3.56/"
+    },
+    map: {
+        main: "index.ts",
+        typescript: "https://unpkg.com/typescript@2.2.2/lib/typescript.js",
+        "@syncfusion/ej2-base": "syncfusion:ej2-base/dist/ej2-base.umd.min.js",
+        "@syncfusion/ej2-data": "syncfusion:ej2-data/dist/ej2-data.umd.min.js",
+        "@syncfusion/ej2-buttons": "syncfusion:ej2-buttons/dist/ej2-buttons.umd.min.js",
+        "@syncfusion/ej2-splitbuttons": "syncfusion:ej2-splitbuttons/dist/ej2-splitbuttons.umd.min.js",
+        "@syncfusion/ej2-popups": "syncfusion:ej2-popups/dist/ej2-popups.umd.min.js",
+        "@syncfusion/ej2-inputs": "syncfusion:ej2-inputs/dist/ej2-inputs.umd.min.js",
+        "@syncfusion/ej2-lists": "syncfusion:ej2-lists/dist/ej2-lists.umd.min.js",
+        "@syncfusion/ej2-dropdowns": "syncfusion:ej2-dropdowns/dist/ej2-dropdowns.umd.min.js",
+        "@syncfusion/ej2-navigations": "syncfusion:ej2-navigations/dist/ej2-navigations.umd.min.js",
+        "@syncfusion/ej2-ribbon": "syncfusion:ej2-ribbon/dist/ej2-ribbon.umd.min.js",
+        "@syncfusion/ej2-notifications": "syncfusion:ej2-notifications/dist/ej2-notifications.umd.min.js"
+    }
+});
+
+System.import('index.ts').catch(console.error.bind(console)).then(function () {
+    document.getElementById('loader').style.display = "none";
+    document.getElementById('container').style.visibility = "visible";
+});

--- a/ej2-javascript/code-snippet/ribbon/item-keytip/ts/index.html
+++ b/ej2-javascript/code-snippet/ribbon/item-keytip/ts/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+            <script src="https://cdn.syncfusion.com/ej2/syncfusion-helper.js"></script>
+    <title>Essential JS 2 - Ribbon</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+    <meta name="description" content="Essential JS 2" />
+    <meta name="author" content="Syncfusion" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-base/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-buttons/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-popups/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-splitbuttons/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-inputs/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-lists/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-dropdowns/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-navigations/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-ribbon/styles/material.css" rel="stylesheet" />
+
+    <!--system js reference and configuration-->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/systemjs/0.19.38/system.js"></script>
+    <script src="systemjs.config.js"></script>
+</head>
+<body>
+    <div id='loader'>LOADING....</div>
+    <div id='container'>
+        <div id="ribbon"></div>
+    </div>
+</body>
+
+</html>

--- a/ej2-javascript/code-snippet/ribbon/launcher-keytip/index.js
+++ b/ej2-javascript/code-snippet/ribbon/launcher-keytip/index.js
@@ -1,0 +1,63 @@
+var tabs = [
+  {
+    header: "Home",
+    keyTip: "H",
+    groups: [
+      {
+        header: "Clipboard",
+        showLauncherIcon: true,
+        launcherIconKeyTip: "L",
+        collections: [
+          {
+            items: [
+              {
+                type: "Button",
+                buttonSettings: {
+                  content: "Paste",
+                  iconCss: "e-icons e-paste",
+                }
+              },
+            ],
+          },
+          {
+            items: [
+              {
+                type: "Button",
+                buttonSettings: {
+                  content: "Cut",
+                  iconCss: "e-icons e-cut",
+                }
+              },
+              {
+                type: "Button",
+                buttonSettings: {
+                  content: "Copy",
+                  iconCss: "e-icons e-copy",
+                }
+              },
+            ],
+          }
+        ]
+      }
+    ]
+  }
+];
+
+var fileMenuItems = [
+    { text: "New", iconCss: "e-icons e-file-new", id: "new" },
+    { text: "Open", iconCss: "e-icons e-folder-open", id: "Open" },
+    { text: "Rename", iconCss: "e-icons e-rename", id: "rename" },
+    { text: "Save as", iconCss: "e-icons e-save", id: "save" }
+];
+
+var ribbon = new ej.ribbon.Ribbon({
+    tabs: tabs,
+    fileMenu: {
+        menuItems: fileMenuItems,
+        visible: true
+    },
+    enableKeyTips: true
+});
+ribbon.appendTo("#ribbon");
+ribbon.ribbonKeyTipModule.showKeyTips('H');
+

--- a/ej2-javascript/code-snippet/ribbon/launcher-keytip/index.js
+++ b/ej2-javascript/code-snippet/ribbon/launcher-keytip/index.js
@@ -11,10 +11,12 @@ var tabs = [
           {
             items: [
               {
-                type: "Button",
-                buttonSettings: {
-                  content: "Paste",
-                  iconCss: "e-icons e-paste",
+                type: 'SplitButton',
+                allowedSizes: ej.ribbon.RibbonItemSize.Large,
+                splitButtonSettings: {
+                  content: 'Paste',
+                  iconCss: 'e-icons e-paste',
+                  items: [{ text: 'Keep Source Format' }, { text: 'Merge format' }, { text: 'Keep text only' }]
                 }
               },
             ],

--- a/ej2-javascript/code-snippet/ribbon/launcher-keytip/index.ts
+++ b/ej2-javascript/code-snippet/ribbon/launcher-keytip/index.ts
@@ -1,0 +1,70 @@
+
+
+import { Ribbon, RibbonTabModel, RibbonItemType, RibbonFileMenu, RibbonKeyTip } from "@syncfusion/ej2-ribbon";
+import { MenuItemModel } from "@syncfusion/ej2-navigations";
+
+Ribbon.Inject(RibbonFileMenu, RibbonKeyTip);
+
+let tabs: RibbonTabModel[] = [
+  {
+    header: "Home",
+    keyTip: "H",
+    groups: [
+      {
+        header: "Clipboard",
+        showLauncherIcon: true,
+        launcherIconKeyTip: "L",
+        collections: [
+          {
+            items: [
+              {
+                type: RibbonItemType.Button,
+                buttonSettings: {
+                  content: "Paste",
+                  iconCss: "e-icons e-paste",
+                }
+              },
+            ],
+          },
+          {
+            items: [
+              {
+                type: RibbonItemType.Button,
+                buttonSettings: {
+                  content: "Cut",
+                  iconCss: "e-icons e-cut",
+                }
+              },
+              {
+                type: RibbonItemType.Button,
+                buttonSettings: {
+                  content: "Copy",
+                  iconCss: "e-icons e-copy",
+                }
+              },
+            ],
+          }
+        ]
+      }
+    ]
+  }
+];
+
+let fileMenuItems: MenuItemModel[] = [
+    { text: "New", iconCss: "e-icons e-file-new", id: "new" },
+    { text: "Open", iconCss: "e-icons e-folder-open", id: "Open" },
+    { text: "Rename", iconCss: "e-icons e-rename", id: "rename" },
+    { text: "Save as", iconCss: "e-icons e-save", id: "save" }
+];
+
+let ribbon: Ribbon = new Ribbon({
+    tabs: tabs,
+    fileMenu: {
+        menuItems: fileMenuItems,
+        visible: true
+    },
+    enableKeyTips: true
+});
+ribbon.appendTo("#ribbon");
+ribbon.ribbonKeyTipModule.showKeyTips('H');
+

--- a/ej2-javascript/code-snippet/ribbon/launcher-keytip/index.ts
+++ b/ej2-javascript/code-snippet/ribbon/launcher-keytip/index.ts
@@ -1,6 +1,6 @@
 
 
-import { Ribbon, RibbonTabModel, RibbonItemType, RibbonFileMenu, RibbonKeyTip } from "@syncfusion/ej2-ribbon";
+import { Ribbon, RibbonTabModel, RibbonItemType, RibbonItemSize, RibbonFileMenu, RibbonKeyTip } from "@syncfusion/ej2-ribbon";
 import { MenuItemModel } from "@syncfusion/ej2-navigations";
 
 Ribbon.Inject(RibbonFileMenu, RibbonKeyTip);
@@ -18,10 +18,12 @@ let tabs: RibbonTabModel[] = [
           {
             items: [
               {
-                type: RibbonItemType.Button,
-                buttonSettings: {
-                  content: "Paste",
-                  iconCss: "e-icons e-paste",
+                type: RibbonItemType.SplitButton,
+                allowedSizes: RibbonItemSize.Large,
+                splitButtonSettings: {
+                    content: 'Paste',
+                    iconCss: 'e-icons e-paste',
+                    items: [{ text: 'Keep Source Format' }, { text: 'Merge format' }, { text: 'Keep text only' }]
                 }
               },
             ],

--- a/ej2-javascript/code-snippet/ribbon/launcher-keytip/js/index.html
+++ b/ej2-javascript/code-snippet/ribbon/launcher-keytip/js/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html><html lang="en"><head>
+            <script src="https://cdn.syncfusion.com/ej2/syncfusion-helper.js"></script>
+    <title>Essential JS 2 - Ribbon</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="description" content="Essential JS 2">
+    <meta name="author" content="Syncfusion">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-base/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-buttons/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-popups/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-splitbuttons/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-inputs/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-lists/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-dropdowns/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-navigations/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-ribbon/styles/material.css" rel="stylesheet">
+
+    <!--system js reference and configuration-->
+    
+    
+<script src="https://cdn.syncfusion.com/ej2/20.3.56/dist/ej2.min.js" type="text/javascript"></script>
+</head>
+<body>
+    
+    <div id="container">
+        <div id="ribbon"></div>
+    </div>
+
+
+
+<script>
+var ele = document.getElementById('container');
+if(ele) {
+    ele.style.visibility = "visible";
+ }   
+        </script>
+<script src="index.js" type="text/javascript"></script>
+</body></html>

--- a/ej2-javascript/code-snippet/ribbon/launcher-keytip/systemjs.config.js
+++ b/ej2-javascript/code-snippet/ribbon/launcher-keytip/systemjs.config.js
@@ -1,0 +1,35 @@
+System.config({
+    transpiler: "typescript",
+    typescriptOptions: {
+        compilerOptions: {
+            target: "umd",
+            module: "commonjs",
+            moduleResolution: "node",
+            emitDecoratorMetadata: true,
+            experimentalDecorators: true
+        }
+    },
+    paths: {
+        "syncfusion:": "https://cdn.syncfusion.com/ej2/20.3.56/"
+    },
+    map: {
+        main: "index.ts",
+        typescript: "https://unpkg.com/typescript@2.2.2/lib/typescript.js",
+        "@syncfusion/ej2-base": "syncfusion:ej2-base/dist/ej2-base.umd.min.js",
+        "@syncfusion/ej2-data": "syncfusion:ej2-data/dist/ej2-data.umd.min.js",
+        "@syncfusion/ej2-buttons": "syncfusion:ej2-buttons/dist/ej2-buttons.umd.min.js",
+        "@syncfusion/ej2-splitbuttons": "syncfusion:ej2-splitbuttons/dist/ej2-splitbuttons.umd.min.js",
+        "@syncfusion/ej2-popups": "syncfusion:ej2-popups/dist/ej2-popups.umd.min.js",
+        "@syncfusion/ej2-inputs": "syncfusion:ej2-inputs/dist/ej2-inputs.umd.min.js",
+        "@syncfusion/ej2-lists": "syncfusion:ej2-lists/dist/ej2-lists.umd.min.js",
+        "@syncfusion/ej2-dropdowns": "syncfusion:ej2-dropdowns/dist/ej2-dropdowns.umd.min.js",
+        "@syncfusion/ej2-navigations": "syncfusion:ej2-navigations/dist/ej2-navigations.umd.min.js",
+        "@syncfusion/ej2-ribbon": "syncfusion:ej2-ribbon/dist/ej2-ribbon.umd.min.js",
+        "@syncfusion/ej2-notifications": "syncfusion:ej2-notifications/dist/ej2-notifications.umd.min.js"
+    }
+});
+
+System.import('index.ts').catch(console.error.bind(console)).then(function () {
+    document.getElementById('loader').style.display = "none";
+    document.getElementById('container').style.visibility = "visible";
+});

--- a/ej2-javascript/code-snippet/ribbon/launcher-keytip/ts/index.html
+++ b/ej2-javascript/code-snippet/ribbon/launcher-keytip/ts/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+            <script src="https://cdn.syncfusion.com/ej2/syncfusion-helper.js"></script>
+    <title>Essential JS 2 - Ribbon</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+    <meta name="description" content="Essential JS 2" />
+    <meta name="author" content="Syncfusion" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-base/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-buttons/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-popups/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-splitbuttons/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-inputs/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-lists/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-dropdowns/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-navigations/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-ribbon/styles/material.css" rel="stylesheet" />
+
+    <!--system js reference and configuration-->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/systemjs/0.19.38/system.js"></script>
+    <script src="systemjs.config.js"></script>
+</head>
+<body>
+    <div id='loader'>LOADING....</div>
+    <div id='container'>
+        <div id="ribbon"></div>
+    </div>
+</body>
+<style>
+    #container {
+        visibility: hidden;
+    }
+
+    #loader {
+        color: #008cff;
+        height: 40px;
+        left: 45%;
+        position: absolute;
+        top: 45%;
+        width: 30%;
+    }
+</style>
+</html>

--- a/ej2-javascript/code-snippet/ribbon/layout-switcher-keytip/index.js
+++ b/ej2-javascript/code-snippet/ribbon/layout-switcher-keytip/index.js
@@ -8,10 +8,12 @@ var tabs = [
           {
             items: [
               {
-                type: "Button",
-                buttonSettings: {
-                  content: "Paste",
-                  iconCss: "e-icons e-paste",
+                type: 'SplitButton',
+                allowedSizes: ej.ribbon.RibbonItemSize.Large,
+                splitButtonSettings: {
+                  content: 'Paste',
+                  iconCss: 'e-icons e-paste',
+                  items: [{ text: 'Keep Source Format' }, { text: 'Merge format' }, { text: 'Keep text only' }]
                 }
               },
             ],

--- a/ej2-javascript/code-snippet/ribbon/layout-switcher-keytip/index.js
+++ b/ej2-javascript/code-snippet/ribbon/layout-switcher-keytip/index.js
@@ -1,0 +1,61 @@
+var tabs = [
+  {
+    header: "Home",
+    groups: [
+      {
+        header: "Clipboard",
+        collections: [
+          {
+            items: [
+              {
+                type: "Button",
+                buttonSettings: {
+                  content: "Paste",
+                  iconCss: "e-icons e-paste",
+                }
+              },
+            ],
+          },
+          {
+            items: [
+              {
+                type: "Button",
+                buttonSettings: {
+                  content: "Cut",
+                  iconCss: "e-icons e-cut",
+                }
+              },
+              {
+                type: "Button",
+                buttonSettings: {
+                  content: "Copy",
+                  iconCss: "e-icons e-copy",
+                }
+              },
+            ],
+          }
+        ]
+      }
+    ]
+  }
+];
+
+var fileMenuItems = [
+    { text: "New", iconCss: "e-icons e-file-new", id: "new" },
+    { text: "Open", iconCss: "e-icons e-folder-open", id: "Open" },
+    { text: "Rename", iconCss: "e-icons e-rename", id: "rename" },
+    { text: "Save as", iconCss: "e-icons e-save", id: "save" }
+];
+
+var ribbon = new ej.ribbon.Ribbon({
+    tabs: tabs,
+    fileMenu: {
+        menuItems: fileMenuItems,
+        visible: true
+    },
+    enableKeyTips: true,
+    layoutSwitcherKeyTip: "LS"
+});
+ribbon.appendTo("#ribbon");
+ribbon.ribbonKeyTipModule.showKeyTips();
+

--- a/ej2-javascript/code-snippet/ribbon/layout-switcher-keytip/index.ts
+++ b/ej2-javascript/code-snippet/ribbon/layout-switcher-keytip/index.ts
@@ -1,6 +1,6 @@
 
 
-import { Ribbon, RibbonTabModel, RibbonItemType, RibbonFileMenu, RibbonKeyTip } from "@syncfusion/ej2-ribbon";
+import { Ribbon, RibbonTabModel, RibbonItemType, RibbonItemSize, RibbonFileMenu, RibbonKeyTip } from "@syncfusion/ej2-ribbon";
 import { MenuItemModel } from "@syncfusion/ej2-navigations";
 
 Ribbon.Inject(RibbonFileMenu, RibbonKeyTip);
@@ -15,10 +15,12 @@ let tabs: RibbonTabModel[] = [
           {
             items: [
               {
-                type: RibbonItemType.Button,
-                buttonSettings: {
-                  content: "Paste",
-                  iconCss: "e-icons e-paste",
+                type: RibbonItemType.SplitButton,
+                allowedSizes: RibbonItemSize.Large,
+                splitButtonSettings: {
+                    content: 'Paste',
+                    iconCss: 'e-icons e-paste',
+                    items: [{ text: 'Keep Source Format' }, { text: 'Merge format' }, { text: 'Keep text only' }]
                 }
               },
             ],

--- a/ej2-javascript/code-snippet/ribbon/layout-switcher-keytip/index.ts
+++ b/ej2-javascript/code-snippet/ribbon/layout-switcher-keytip/index.ts
@@ -1,0 +1,68 @@
+
+
+import { Ribbon, RibbonTabModel, RibbonItemType, RibbonFileMenu, RibbonKeyTip } from "@syncfusion/ej2-ribbon";
+import { MenuItemModel } from "@syncfusion/ej2-navigations";
+
+Ribbon.Inject(RibbonFileMenu, RibbonKeyTip);
+
+let tabs: RibbonTabModel[] = [
+  {
+    header: "Home",
+    groups: [
+      {
+        header: "Clipboard",
+        collections: [
+          {
+            items: [
+              {
+                type: RibbonItemType.Button,
+                buttonSettings: {
+                  content: "Paste",
+                  iconCss: "e-icons e-paste",
+                }
+              },
+            ],
+          },
+          {
+            items: [
+              {
+                type: RibbonItemType.Button,
+                buttonSettings: {
+                  content: "Cut",
+                  iconCss: "e-icons e-cut",
+                }
+              },
+              {
+                type: RibbonItemType.Button,
+                buttonSettings: {
+                  content: "Copy",
+                  iconCss: "e-icons e-copy",
+                }
+              },
+            ],
+          }
+        ]
+      }
+    ]
+  }
+];
+
+let fileMenuItems: MenuItemModel[] = [
+    { text: "New", iconCss: "e-icons e-file-new", id: "new" },
+    { text: "Open", iconCss: "e-icons e-folder-open", id: "Open" },
+    { text: "Rename", iconCss: "e-icons e-rename", id: "rename" },
+    { text: "Save as", iconCss: "e-icons e-save", id: "save" }
+];
+
+let ribbon: Ribbon = new Ribbon({
+    tabs: tabs,
+    fileMenu: {
+        menuItems: fileMenuItems,
+        visible: true
+    },
+    enableKeyTips: true,
+    layoutSwitcherKeyTip: "LS"
+});
+ribbon.appendTo("#ribbon");
+ribbon.ribbonKeyTipModule.showKeyTips();
+

--- a/ej2-javascript/code-snippet/ribbon/layout-switcher-keytip/js/index.html
+++ b/ej2-javascript/code-snippet/ribbon/layout-switcher-keytip/js/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html><html lang="en"><head>
+            <script src="https://cdn.syncfusion.com/ej2/syncfusion-helper.js"></script>
+    <title>Essential JS 2 - Ribbon</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="description" content="Essential JS 2">
+    <meta name="author" content="Syncfusion">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-base/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-buttons/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-popups/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-splitbuttons/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-inputs/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-lists/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-dropdowns/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-navigations/styles/material.css" rel="stylesheet">
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-ribbon/styles/material.css" rel="stylesheet">
+
+    <!--system js reference and configuration-->
+    
+    
+<script src="https://cdn.syncfusion.com/ej2/20.3.56/dist/ej2.min.js" type="text/javascript"></script>
+</head>
+<body>
+    
+    <div id="container">
+        <div id="ribbon"></div>
+    </div>
+
+
+
+<script>
+var ele = document.getElementById('container');
+if(ele) {
+    ele.style.visibility = "visible";
+ }   
+        </script>
+<script src="index.js" type="text/javascript"></script>
+</body></html>

--- a/ej2-javascript/code-snippet/ribbon/layout-switcher-keytip/systemjs.config.js
+++ b/ej2-javascript/code-snippet/ribbon/layout-switcher-keytip/systemjs.config.js
@@ -1,0 +1,35 @@
+System.config({
+    transpiler: "typescript",
+    typescriptOptions: {
+        compilerOptions: {
+            target: "umd",
+            module: "commonjs",
+            moduleResolution: "node",
+            emitDecoratorMetadata: true,
+            experimentalDecorators: true
+        }
+    },
+    paths: {
+        "syncfusion:": "https://cdn.syncfusion.com/ej2/20.3.56/"
+    },
+    map: {
+        main: "index.ts",
+        typescript: "https://unpkg.com/typescript@2.2.2/lib/typescript.js",
+        "@syncfusion/ej2-base": "syncfusion:ej2-base/dist/ej2-base.umd.min.js",
+        "@syncfusion/ej2-data": "syncfusion:ej2-data/dist/ej2-data.umd.min.js",
+        "@syncfusion/ej2-buttons": "syncfusion:ej2-buttons/dist/ej2-buttons.umd.min.js",
+        "@syncfusion/ej2-splitbuttons": "syncfusion:ej2-splitbuttons/dist/ej2-splitbuttons.umd.min.js",
+        "@syncfusion/ej2-popups": "syncfusion:ej2-popups/dist/ej2-popups.umd.min.js",
+        "@syncfusion/ej2-inputs": "syncfusion:ej2-inputs/dist/ej2-inputs.umd.min.js",
+        "@syncfusion/ej2-lists": "syncfusion:ej2-lists/dist/ej2-lists.umd.min.js",
+        "@syncfusion/ej2-dropdowns": "syncfusion:ej2-dropdowns/dist/ej2-dropdowns.umd.min.js",
+        "@syncfusion/ej2-navigations": "syncfusion:ej2-navigations/dist/ej2-navigations.umd.min.js",
+        "@syncfusion/ej2-ribbon": "syncfusion:ej2-ribbon/dist/ej2-ribbon.umd.min.js",
+        "@syncfusion/ej2-notifications": "syncfusion:ej2-notifications/dist/ej2-notifications.umd.min.js"
+    }
+});
+
+System.import('index.ts').catch(console.error.bind(console)).then(function () {
+    document.getElementById('loader').style.display = "none";
+    document.getElementById('container').style.visibility = "visible";
+});

--- a/ej2-javascript/code-snippet/ribbon/layout-switcher-keytip/ts/index.html
+++ b/ej2-javascript/code-snippet/ribbon/layout-switcher-keytip/ts/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+            <script src="https://cdn.syncfusion.com/ej2/syncfusion-helper.js"></script>
+    <title>Essential JS 2 - Ribbon</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+    <meta name="description" content="Essential JS 2" />
+    <meta name="author" content="Syncfusion" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-base/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-buttons/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-popups/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-splitbuttons/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-inputs/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-lists/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-dropdowns/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-navigations/styles/material.css" rel="stylesheet" />
+    <link href="https://cdn.syncfusion.com/ej2/20.3.56/ej2-ribbon/styles/material.css" rel="stylesheet" />
+
+    <!--system js reference and configuration-->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/systemjs/0.19.38/system.js"></script>
+    <script src="systemjs.config.js"></script>
+</head>
+<body>
+    <div id='loader'>LOADING....</div>
+    <div id='container'>
+        <div id="ribbon"></div>
+    </div>
+</body>
+<style>
+    #container {
+        visibility: hidden;
+    }
+
+    #loader {
+        color: #008cff;
+        height: 40px;
+        left: 45%;
+        position: absolute;
+        top: 45%;
+        width: 30%;
+    }
+</style>
+</html>

--- a/ej2-javascript/ribbon/ej2-javascript-ribbon-toc.html
+++ b/ej2-javascript/ribbon/ej2-javascript-ribbon-toc.html
@@ -9,6 +9,7 @@ Ribbon
 <li><a href="/ej2-javascript/ribbon/backstage">Backstage Menu</a></li>
 <li><a href="/ej2-javascript/ribbon/help-pane-template">Help Pane Template</a></li>
 <li><a href="/ej2-javascript/ribbon/tooltip">Tooltip</a></li>
+<li><a href="/ej2-javascript/ribbon/keytip">Keytip</a></li>
 <li><a href="/ej2-javascript/ribbon/resizing">Resizing</a></li>
 <li><a href="/ej2-javascript/ribbon/events">Events</a></li>
 <li><a href="/ej2-javascript/ribbon/accessibility">Accessibility</a></li>

--- a/ej2-javascript/ribbon/ej2-javascript-ribbon-toc.html
+++ b/ej2-javascript/ribbon/ej2-javascript-ribbon-toc.html
@@ -7,9 +7,9 @@ Ribbon
 <li><a href="/ej2-javascript/ribbon/layouts">Ribbon Layouts</a></li>
 <li><a href="/ej2-javascript/ribbon/file-menu">File Menu</a></li>
 <li><a href="/ej2-javascript/ribbon/backstage">Backstage Menu</a></li>
+<li><a href="/ej2-javascript/ribbon/keytip">Ribbon Keytips</a></li>
 <li><a href="/ej2-javascript/ribbon/help-pane-template">Help Pane Template</a></li>
 <li><a href="/ej2-javascript/ribbon/tooltip">Tooltip</a></li>
-<li><a href="/ej2-javascript/ribbon/keytip">Keytip</a></li>
 <li><a href="/ej2-javascript/ribbon/resizing">Resizing</a></li>
 <li><a href="/ej2-javascript/ribbon/events">Events</a></li>
 <li><a href="/ej2-javascript/ribbon/accessibility">Accessibility</a></li>

--- a/ej2-javascript/ribbon/ej2-typescript-ribbon-toc.html
+++ b/ej2-javascript/ribbon/ej2-typescript-ribbon-toc.html
@@ -10,6 +10,7 @@ Ribbon
 <li><a href="/ej2-typescript/ribbon/backstage">Backstage Menu</a></li>
 <li><a href="/ej2-typescript/ribbon/help-pane-template">Help Pane Template</a></li>
 <li><a href="/ej2-typescript/ribbon/tooltip">Tooltip</a></li>
+<li><a href="/ej2-typescript/ribbon/keytip">Keytip</a></li>
 <li><a href="/ej2-typescript/ribbon/resizing">Resizing</a></li>
 <li><a href="/ej2-typescript/ribbon/events">Events</a></li>
 <li><a href="/ej2-typescript/ribbon/accessibility">Accessibility</a></li>

--- a/ej2-javascript/ribbon/ej2-typescript-ribbon-toc.html
+++ b/ej2-javascript/ribbon/ej2-typescript-ribbon-toc.html
@@ -8,9 +8,9 @@ Ribbon
 <li><a href="/ej2-typescript/ribbon/layouts">Ribbon Layouts</a></li>
 <li><a href="/ej2-typescript/ribbon/file-menu">File Menu</a></li>
 <li><a href="/ej2-typescript/ribbon/backstage">Backstage Menu</a></li>
+<li><a href="/ej2-typescript/ribbon/keytip">Ribbon Keytips</a></li>
 <li><a href="/ej2-typescript/ribbon/help-pane-template">Help Pane Template</a></li>
 <li><a href="/ej2-typescript/ribbon/tooltip">Tooltip</a></li>
-<li><a href="/ej2-typescript/ribbon/keytip">Keytip</a></li>
 <li><a href="/ej2-typescript/ribbon/resizing">Resizing</a></li>
 <li><a href="/ej2-typescript/ribbon/events">Events</a></li>
 <li><a href="/ej2-typescript/ribbon/accessibility">Accessibility</a></li>

--- a/ej2-javascript/ribbon/js/keytip.md
+++ b/ej2-javascript/ribbon/js/keytip.md
@@ -92,12 +92,12 @@ You can add keytip to the launcher icon by using the `launcherIconKeyTip` proper
 
 ## Guidelines for adding keytips
 
-* The keytip to the ribbon items can have a maximum of three letters. The text count greater than (>3) results in an exception.
+Before adding keytips to the ribbon items consider the following:
 
 * Avoid using the same keytip setting on multiple items.
 
-> For example: When you add the keytip text "H" or "HF" for the same items, it activates the first item occurrence of "H", while any subsequent instances of "H" or "HF" are ignored.
+> For example: When you add the keytip text `H` or `HF` for the same items, it activates the first item occurrence of `H`, while any subsequent instances of `H` or `HF` are ignored.
 
 * Do not use the same first letter for the single and double keytip items.
 
-> For example: When accessing keytip text F, FP and FPF added for the different ribbon items and pressing F key, only the F key tip associated item will be activated while the FP, FPF associated ribbon items will be ignored.
+> For example: When accessing keytip text `F`, `FP` and `FPF` added for the different ribbon items and pressing `F` key, only the `F` key tip associated item will be activated while the `FP`, `FPF` configured ribbon items will be ignored.

--- a/ej2-javascript/ribbon/js/keytip.md
+++ b/ej2-javascript/ribbon/js/keytip.md
@@ -1,0 +1,99 @@
+---
+layout: post
+title: Ribbon Keytip in  ##Platform_Name## Ribbon control | Syncfusion
+description:  Checkout and learn about Ribbon Keytip with ##Platform_Name## Ribbon control of Syncfusion Essential JS 2 and more details.
+platform: ej2-javascript
+control: Ribbon
+publishingplatform: ##Platform_Name##
+documentation: ug
+domainurl: ##DomainURL##
+---
+
+# Ribbon Keytip
+
+The Ribbon supports keytips, which enhance user accessibility and efficiency by providing keyboard shortcuts for navigating through the ribbon interface without the need for a mouse. The keytip can be enabled by setting the `enableKeyTips` property.
+
+The keytips will be displayed when the Alt + Windows/Command key is pressed.
+
+## Ribbon items keytip
+
+You can add keytip to all the ribbon items by using the `keyTip` property.
+
+{% tabs %}
+{% highlight js tabtitle="index.js" %}
+{% include code-snippet/ribbon/item-keytip/index.js %}
+{% endhighlight %}
+{% highlight html tabtitle="index.html" %}
+{% include code-snippet/ribbon/item-keytip/index.html %}
+{% endhighlight %}
+{% endtabs %}
+          
+{% previewsample "page.domainurl/code-snippet/ribbon/item-keytip" %}
+
+## Ribbon file menu keytip
+
+You can add keytip to file menu by using the `keyTip` property.
+
+{% tabs %}
+{% highlight js tabtitle="index.js" %}
+{% include code-snippet/ribbon/filemenu-keytip/index.js %}
+{% endhighlight %}
+{% highlight html tabtitle="index.html" %}
+{% include code-snippet/ribbon/filemenu-keytip/index.html %}
+{% endhighlight %}
+{% endtabs %}
+          
+{% previewsample "page.domainurl/code-snippet/ribbon/filemenu-keytip" %}
+
+## Ribbon backstage menu keytip
+
+You can add keytip to backstage menu by using the `keyTip` property.
+
+{% tabs %}
+{% highlight js tabtitle="index.js" %}
+{% include code-snippet/ribbon/backstagemenu-keytip/index.js %}
+{% endhighlight %}
+{% highlight html tabtitle="index.html" %}
+{% include code-snippet/ribbon/backstagemenu-keytip/index.html %}
+{% endhighlight %}
+{% endtabs %}
+          
+{% previewsample "page.domainurl/code-snippet/ribbon/backstagemenu-keytip" %}
+
+## Ribbon layout switcher keytip
+
+You can add keytip to layout switcher by using the `layoutSwitcherKeyTip` property.
+
+{% tabs %}
+{% highlight js tabtitle="index.js" %}
+{% include code-snippet/ribbon/layout-switcher-keytip/index.js %}
+{% endhighlight %}
+{% highlight html tabtitle="index.html" %}
+{% include code-snippet/ribbon/layout-switcher-keytip/index.html %}
+{% endhighlight %}
+{% endtabs %}
+          
+{% previewsample "page.domainurl/code-snippet/ribbon/layout-switcher-keytip" %}
+
+## Ribbon launcher icon keytip
+
+You can add keytip to launcher icon by using the `launcherIconKeyTip` property.
+
+{% tabs %}
+{% highlight js tabtitle="index.js" %}
+{% include code-snippet/ribbon/launcher-keytip/index.js %}
+{% endhighlight %}
+{% highlight html tabtitle="index.html" %}
+{% include code-snippet/ribbon/launcher-keytip/index.html %}
+{% endhighlight %}
+{% endtabs %}
+          
+{% previewsample "page.domainurl/code-snippet/ribbon/launcher-keytip" %}
+
+## Guidelines for adding keytips
+
+* The keytip to the ribbon elements can have a maximum of three letters. A deviation from the text count (>3) results in an exception.
+
+* Avoid using the same keytip setting on multiple elements.
+
+* Do not use the same first letter for the single and double keytip elements.

--- a/ej2-javascript/ribbon/js/keytip.md
+++ b/ej2-javascript/ribbon/js/keytip.md
@@ -9,15 +9,15 @@ documentation: ug
 domainurl: ##DomainURL##
 ---
 
-# Ribbon Keytip
+# Ribbon Keytips
 
-The Ribbon supports keytips, which enhance user accessibility and efficiency by providing keyboard shortcuts for navigating through the ribbon interface without the need for a mouse. The keytip can be enabled by setting the `enableKeyTips` property.
+The Ribbon supports keyboard navigations to interact the ribbon items using the keytips which can be enabled by setting the `enableKeyTips` property.
 
-The keytips will be displayed when the Alt + Windows/Command key is pressed.
+The keytips will be shown when the `Alt + Windows/Command` keys are pressed.
 
 ## Ribbon items keytip
 
-You can add keytip to all the ribbon items by using the `keyTip` property.
+You can add keytips to all the ribbon items by using the `keyTip` property.
 
 {% tabs %}
 {% highlight js tabtitle="index.js" %}
@@ -30,9 +30,9 @@ You can add keytip to all the ribbon items by using the `keyTip` property.
           
 {% previewsample "page.domainurl/code-snippet/ribbon/item-keytip" %}
 
-## Ribbon file menu keytip
+## File menu keytip
 
-You can add keytip to file menu by using the `keyTip` property.
+You can add keytips to the file menu by using the `keyTip` property.
 
 {% tabs %}
 {% highlight js tabtitle="index.js" %}
@@ -45,9 +45,9 @@ You can add keytip to file menu by using the `keyTip` property.
           
 {% previewsample "page.domainurl/code-snippet/ribbon/filemenu-keytip" %}
 
-## Ribbon backstage menu keytip
+## Backstage menu keytip
 
-You can add keytip to backstage menu by using the `keyTip` property.
+You can add keytips to backstage menu items by using the `keyTip` property.
 
 {% tabs %}
 {% highlight js tabtitle="index.js" %}
@@ -62,7 +62,7 @@ You can add keytip to backstage menu by using the `keyTip` property.
 
 ## Ribbon layout switcher keytip
 
-You can add keytip to layout switcher by using the `layoutSwitcherKeyTip` property.
+You can add keytip to the layout switcher by using the `layoutSwitcherKeyTip` property.
 
 {% tabs %}
 {% highlight js tabtitle="index.js" %}
@@ -77,7 +77,7 @@ You can add keytip to layout switcher by using the `layoutSwitcherKeyTip` proper
 
 ## Ribbon launcher icon keytip
 
-You can add keytip to launcher icon by using the `launcherIconKeyTip` property.
+You can add keytip to the launcher icon by using the `launcherIconKeyTip` property.
 
 {% tabs %}
 {% highlight js tabtitle="index.js" %}
@@ -92,8 +92,12 @@ You can add keytip to launcher icon by using the `launcherIconKeyTip` property.
 
 ## Guidelines for adding keytips
 
-* The keytip to the ribbon elements can have a maximum of three letters. A deviation from the text count (>3) results in an exception.
+* The keytip to the ribbon items can have a maximum of three letters. The text count greater than (>3) results in an exception.
 
-* Avoid using the same keytip setting on multiple elements.
+* Avoid using the same keytip setting on multiple items.
 
-* Do not use the same first letter for the single and double keytip elements.
+> For example: When you add the keytip text "H" or "HF" for the same items, it activates the first item occurrence of "H", while any subsequent instances of "H" or "HF" are ignored.
+
+* Do not use the same first letter for the single and double keytip items.
+
+> For example: When accessing keytip text F, FP and FPF added for the different ribbon items and pressing F key, only the F key tip associated item will be activated while the FP, FPF associated ribbon items will be ignored.

--- a/ej2-javascript/ribbon/js/keytip.md
+++ b/ej2-javascript/ribbon/js/keytip.md
@@ -96,11 +96,11 @@ You can add keytip to the launcher icon by using the [launcherIconKeyTip](https:
 
 You can use the [showKeyTips](https://ej2.syncfusion.com/javascript/documentation/api/ribbon/ribbonKeyTip/#showkeytips) method to shown the keytips dynamically.
 
-In order to show specific keytips, pass the key string as an argument in the `showKeyTips` method.
+In order to show specific keytips, pass the key string as an argument in the `showKeyTips('H')` method.
 
 ### Hide keytips
 
-You can remove the keytips dynamically using the [hideKeyTips](https://ej2.syncfusion.com/javascript/documentation/api/ribbon/ribbonKeyTip/#hidekeytips) method in the Ribbon. This will remove all the visible keytips.
+You can use the [hideKeyTips](https://ej2.syncfusion.com/javascript/documentation/api/ribbon/ribbonKeyTip/#hidekeytips) method in Ribbon to remove the keytips dynamically. This will remove all the visible keytips.
 
 ## Guidelines for adding keytips
 

--- a/ej2-javascript/ribbon/js/keytip.md
+++ b/ej2-javascript/ribbon/js/keytip.md
@@ -11,13 +11,13 @@ domainurl: ##DomainURL##
 
 # Ribbon Keytips
 
-The Ribbon supports keyboard navigations to interact the ribbon items using the keytips which can be enabled by setting the `enableKeyTips` property.
+The Ribbon supports keyboard navigations to interact the ribbon items using the keytips which can be enabled by setting the [enableKeyTips](https://ej2.syncfusion.com/javascript/documentation/api/ribbon/#enablekeytips) property.
 
 The keytips will be shown when the `Alt + Windows/Command` keys are pressed.
 
 ## Ribbon items keytip
 
-You can add keytips to all the ribbon items by using the `keyTip` property.
+You can add keytips to all the ribbon items by using the [keyTip](https://ej2.syncfusion.com/javascript/documentation/api/ribbon/ribbonItem/#keytip) property.
 
 {% tabs %}
 {% highlight js tabtitle="index.js" %}
@@ -32,7 +32,7 @@ You can add keytips to all the ribbon items by using the `keyTip` property.
 
 ## File menu keytip
 
-You can add keytips to the file menu by using the `keyTip` property.
+You can add keytips to the file menu by using the [keyTip](https://ej2.syncfusion.com/javascript/documentation/api/ribbon/fileMenuSettings/#keytip) property.
 
 {% tabs %}
 {% highlight js tabtitle="index.js" %}
@@ -47,7 +47,7 @@ You can add keytips to the file menu by using the `keyTip` property.
 
 ## Backstage menu keytip
 
-You can add keytips to backstage menu items by using the `keyTip` property.
+You can add keytips to backstage menu items by using the [keyTip](https://ej2.syncfusion.com/javascript/documentation/api/ribbon/backStageMenu/#keytip) property.
 
 {% tabs %}
 {% highlight js tabtitle="index.js" %}
@@ -62,7 +62,7 @@ You can add keytips to backstage menu items by using the `keyTip` property.
 
 ## Ribbon layout switcher keytip
 
-You can add keytip to the layout switcher by using the `layoutSwitcherKeyTip` property.
+You can add keytip to the layout switcher by using the [layoutSwitcherKeyTip](https://ej2.syncfusion.com/javascript/documentation/api/ribbon/#layoutswitcherkeytip) property.
 
 {% tabs %}
 {% highlight js tabtitle="index.js" %}
@@ -77,7 +77,7 @@ You can add keytip to the layout switcher by using the `layoutSwitcherKeyTip` pr
 
 ## Ribbon launcher icon keytip
 
-You can add keytip to the launcher icon by using the `launcherIconKeyTip` property.
+You can add keytip to the launcher icon by using the [launcherIconKeyTip](https://ej2.syncfusion.com/javascript/documentation/api/ribbon/ribbonGroup/#launchericonkeytip) property.
 
 {% tabs %}
 {% highlight js tabtitle="index.js" %}
@@ -89,6 +89,18 @@ You can add keytip to the launcher icon by using the `launcherIconKeyTip` proper
 {% endtabs %}
           
 {% previewsample "page.domainurl/code-snippet/ribbon/launcher-keytip" %}
+
+## Methods
+
+### Show keytips
+
+You can use the [showKeyTips](https://ej2.syncfusion.com/javascript/documentation/api/ribbon/ribbonKeyTip/#showkeytips) method to shown the keytips dynamically.
+
+In order to show specific keytips, pass the key string as an argument in the `showKeyTips` method.
+
+### Hide keytips
+
+You can remove the keytips dynamically using the [hideKeyTips](https://ej2.syncfusion.com/javascript/documentation/api/ribbon/ribbonKeyTip/#hidekeytips) method in the Ribbon. This will remove all the visible keytips.
 
 ## Guidelines for adding keytips
 

--- a/ej2-javascript/ribbon/ts/keytip.md
+++ b/ej2-javascript/ribbon/ts/keytip.md
@@ -9,15 +9,15 @@ documentation: ug
 domainurl: ##DomainURL##
 ---
 
-# Ribbon Keytip
+# Ribbon Keytips
 
-The Ribbon supports keytips, which enhance user accessibility and efficiency by providing keyboard shortcuts for navigating through the ribbon interface without the need for a mouse. The keytip can be enabled by setting the `enableKeyTips` property.
+The Ribbon supports keyboard navigations to interact the ribbon items using the keytips which can be enabled by setting the `enableKeyTips` property.
 
-The keytips will be displayed when the Alt + Windows/Command key is pressed.
+The keytips will be shown when the `Alt + Windows/Command` keys are pressed.
 
 ## Ribbon items keytip
 
-You can add keytip to all the ribbon items by using the `keyTip` property.
+You can add keytips to all the ribbon items by using the `keyTip` property.
 
 {% tabs %}
 {% highlight ts tabtitle="index.ts" %}
@@ -30,9 +30,9 @@ You can add keytip to all the ribbon items by using the `keyTip` property.
           
 {% previewsample "page.domainurl/code-snippet/ribbon/item-keytip" %}
 
-## Ribbon file menu keytip
+## File menu keytip
 
-You can add keytip to file menu by using the `keyTip` property.
+You can add keytips to the file menu by using the `keyTip` property.
 
 {% tabs %}
 {% highlight ts tabtitle="index.ts" %}
@@ -45,9 +45,9 @@ You can add keytip to file menu by using the `keyTip` property.
           
 {% previewsample "page.domainurl/code-snippet/ribbon/filemenu-keytip" %}
 
-## Ribbon backstage menu keytip
+## Backstage menu keytip
 
-You can add keytip to backstage menu by using the `keyTip` property.
+You can add keytips to backstage menu items by using the `keyTip` property.
 
 {% tabs %}
 {% highlight ts tabtitle="index.ts" %}
@@ -62,7 +62,7 @@ You can add keytip to backstage menu by using the `keyTip` property.
 
 ## Ribbon layout switcher keytip
 
-You can add keytip to layout switcher by using the `layoutSwitcherKeyTip` property.
+You can add keytip to the layout switcher by using the `layoutSwitcherKeyTip` property.
 
 {% tabs %}
 {% highlight ts tabtitle="index.ts" %}
@@ -77,7 +77,7 @@ You can add keytip to layout switcher by using the `layoutSwitcherKeyTip` proper
 
 ## Ribbon launcher icon keytip
 
-You can add keytip to launcher icon by using the `launcherIconKeyTip` property.
+You can add keytip to the launcher icon by using the `launcherIconKeyTip` property.
 
 {% tabs %}
 {% highlight ts tabtitle="index.ts" %}
@@ -92,8 +92,12 @@ You can add keytip to launcher icon by using the `launcherIconKeyTip` property.
 
 ## Guidelines for adding keytips
 
-* The keytip to the ribbon elements can have a maximum of three letters. A deviation from the text count (>3) results in an exception.
+* The keytip to the ribbon items can have a maximum of three letters. The text count greater than (>3) results in an exception.
 
-* Avoid using the same keytip setting on multiple elements.
+* Avoid using the same keytip setting on multiple items.
 
-* Do not use the same first letter for the single and double keytip elements.
+> For example: When you add the keytip text "H" or "HF" for the same items, it activates the first item occurrence of "H", while any subsequent instances of "H" or "HF" are ignored.
+
+* Do not use the same first letter for the single and double keytip items.
+
+> For example: When accessing keytip text F, FP and FPF added for the different ribbon items and pressing F key, only the F key tip associated item will be activated while the FP, FPF associated ribbon items will be ignored.

--- a/ej2-javascript/ribbon/ts/keytip.md
+++ b/ej2-javascript/ribbon/ts/keytip.md
@@ -92,12 +92,12 @@ You can add keytip to the launcher icon by using the `launcherIconKeyTip` proper
 
 ## Guidelines for adding keytips
 
-* The keytip to the ribbon items can have a maximum of three letters. The text count greater than (>3) results in an exception.
+Before adding keytips to the ribbon items consider the following:
 
 * Avoid using the same keytip setting on multiple items.
 
-> For example: When you add the keytip text "H" or "HF" for the same items, it activates the first item occurrence of "H", while any subsequent instances of "H" or "HF" are ignored.
+> For example: When you add the keytip text `H` or `HF` for the same items, it activates the first item occurrence of `H`, while any subsequent instances of `H` or `HF` are ignored.
 
 * Do not use the same first letter for the single and double keytip items.
 
-> For example: When accessing keytip text F, FP and FPF added for the different ribbon items and pressing F key, only the F key tip associated item will be activated while the FP, FPF associated ribbon items will be ignored.
+> For example: When accessing keytip text `F`, `FP` and `FPF` added for the different ribbon items and pressing `F` key, only the `F` key tip associated item will be activated while the `FP`, `FPF` configured ribbon items will be ignored.

--- a/ej2-javascript/ribbon/ts/keytip.md
+++ b/ej2-javascript/ribbon/ts/keytip.md
@@ -1,0 +1,99 @@
+---
+layout: post
+title: Ribbon Keytip in  ##Platform_Name## Ribbon control | Syncfusion
+description:  Checkout and learn about Ribbon Keytip with ##Platform_Name## Ribbon control of Syncfusion Essential ts 2 and more details.
+platform: ej2-javascript
+control: Ribbon
+publishingplatform: ##Platform_Name##
+documentation: ug
+domainurl: ##DomainURL##
+---
+
+# Ribbon Keytip
+
+The Ribbon supports keytips, which enhance user accessibility and efficiency by providing keyboard shortcuts for navigating through the ribbon interface without the need for a mouse. The keytip can be enabled by setting the `enableKeyTips` property.
+
+The keytips will be displayed when the Alt + Windows/Command key is pressed.
+
+## Ribbon items keytip
+
+You can add keytip to all the ribbon items by using the `keyTip` property.
+
+{% tabs %}
+{% highlight ts tabtitle="index.ts" %}
+{% include code-snippet/ribbon/item-keytip/index.ts %}
+{% endhighlight %}
+{% highlight html tabtitle="index.html" %}
+{% include code-snippet/ribbon/item-keytip/index.html %}
+{% endhighlight %}
+{% endtabs %}
+          
+{% previewsample "page.domainurl/code-snippet/ribbon/item-keytip" %}
+
+## Ribbon file menu keytip
+
+You can add keytip to file menu by using the `keyTip` property.
+
+{% tabs %}
+{% highlight ts tabtitle="index.ts" %}
+{% include code-snippet/ribbon/filemenu-keytip/index.ts %}
+{% endhighlight %}
+{% highlight html tabtitle="index.html" %}
+{% include code-snippet/ribbon/filemenu-keytip/index.html %}
+{% endhighlight %}
+{% endtabs %}
+          
+{% previewsample "page.domainurl/code-snippet/ribbon/filemenu-keytip" %}
+
+## Ribbon backstage menu keytip
+
+You can add keytip to backstage menu by using the `keyTip` property.
+
+{% tabs %}
+{% highlight ts tabtitle="index.ts" %}
+{% include code-snippet/ribbon/backstagemenu-keytip/index.ts %}
+{% endhighlight %}
+{% highlight html tabtitle="index.html" %}
+{% include code-snippet/ribbon/backstagemenu-keytip/index.html %}
+{% endhighlight %}
+{% endtabs %}
+          
+{% previewsample "page.domainurl/code-snippet/ribbon/backstagemenu-keytip" %}
+
+## Ribbon layout switcher keytip
+
+You can add keytip to layout switcher by using the `layoutSwitcherKeyTip` property.
+
+{% tabs %}
+{% highlight ts tabtitle="index.ts" %}
+{% include code-snippet/ribbon/layout-switcher-keytip/index.ts %}
+{% endhighlight %}
+{% highlight html tabtitle="index.html" %}
+{% include code-snippet/ribbon/layout-switcher-keytip/index.html %}
+{% endhighlight %}
+{% endtabs %}
+          
+{% previewsample "page.domainurl/code-snippet/ribbon/layout-switcher-keytip" %}
+
+## Ribbon launcher icon keytip
+
+You can add keytip to launcher icon by using the `launcherIconKeyTip` property.
+
+{% tabs %}
+{% highlight ts tabtitle="index.ts" %}
+{% include code-snippet/ribbon/launcher-keytip/index.ts %}
+{% endhighlight %}
+{% highlight html tabtitle="index.html" %}
+{% include code-snippet/ribbon/launcher-keytip/index.html %}
+{% endhighlight %}
+{% endtabs %}
+          
+{% previewsample "page.domainurl/code-snippet/ribbon/launcher-keytip" %}
+
+## Guidelines for adding keytips
+
+* The keytip to the ribbon elements can have a maximum of three letters. A deviation from the text count (>3) results in an exception.
+
+* Avoid using the same keytip setting on multiple elements.
+
+* Do not use the same first letter for the single and double keytip elements.

--- a/ej2-javascript/ribbon/ts/keytip.md
+++ b/ej2-javascript/ribbon/ts/keytip.md
@@ -96,11 +96,11 @@ You can add keytip to the launcher icon by using the [launcherIconKeyTip](https:
 
 You can use the [showKeyTips](https://ej2.syncfusion.com/documentation/api/ribbon/ribbonKeyTip/#showkeytips) method to shown the keytips dynamically.
 
-In order to show specific keytips, pass the key string as an argument in the `showKeyTips` method.
+In order to show specific keytips, pass the key string as an argument in the `showKeyTips('H')` method.
 
 ### Hide keytips
 
-You can remove the keytips dynamically using the [hideKeyTips](https://ej2.syncfusion.com/documentation/api/ribbon/ribbonKeyTip/#hidekeytips) method in the Ribbon. This will remove all the visible keytips.
+You can use the [hideKeyTips](https://ej2.syncfusion.com/documentation/api/ribbon/ribbonKeyTip/#hidekeytips) method in Ribbon to remove the keytips dynamically. This will remove all the visible keytips.
 
 ## Guidelines for adding keytips
 

--- a/ej2-javascript/ribbon/ts/keytip.md
+++ b/ej2-javascript/ribbon/ts/keytip.md
@@ -11,13 +11,13 @@ domainurl: ##DomainURL##
 
 # Ribbon Keytips
 
-The Ribbon supports keyboard navigations to interact the ribbon items using the keytips which can be enabled by setting the `enableKeyTips` property.
+The Ribbon supports keyboard navigations to interact the ribbon items using the keytips which can be enabled by setting the [enableKeyTips](https://ej2.syncfusion.com/documentation/api/ribbon/#enablekeytips) property.
 
 The keytips will be shown when the `Alt + Windows/Command` keys are pressed.
 
 ## Ribbon items keytip
 
-You can add keytips to all the ribbon items by using the `keyTip` property.
+You can add keytips to all the ribbon items by using the [keyTip](https://ej2.syncfusion.com/documentation/api/ribbon/ribbonItem/#keytip) property.
 
 {% tabs %}
 {% highlight ts tabtitle="index.ts" %}
@@ -32,7 +32,7 @@ You can add keytips to all the ribbon items by using the `keyTip` property.
 
 ## File menu keytip
 
-You can add keytips to the file menu by using the `keyTip` property.
+You can add keytips to the file menu by using the [keyTip](https://ej2.syncfusion.com/documentation/api/ribbon/fileMenuSettings/#keytip) property.
 
 {% tabs %}
 {% highlight ts tabtitle="index.ts" %}
@@ -47,7 +47,7 @@ You can add keytips to the file menu by using the `keyTip` property.
 
 ## Backstage menu keytip
 
-You can add keytips to backstage menu items by using the `keyTip` property.
+You can add keytips to backstage menu items by using the [keyTip](https://ej2.syncfusion.com/documentation/api/ribbon/backStageMenu/#keytip) property.
 
 {% tabs %}
 {% highlight ts tabtitle="index.ts" %}
@@ -62,7 +62,7 @@ You can add keytips to backstage menu items by using the `keyTip` property.
 
 ## Ribbon layout switcher keytip
 
-You can add keytip to the layout switcher by using the `layoutSwitcherKeyTip` property.
+You can add keytip to the layout switcher by using the [layoutSwitcherKeyTip](https://ej2.syncfusion.com/documentation/api/ribbon#layoutswitcherkeytip) property.
 
 {% tabs %}
 {% highlight ts tabtitle="index.ts" %}
@@ -77,7 +77,7 @@ You can add keytip to the layout switcher by using the `layoutSwitcherKeyTip` pr
 
 ## Ribbon launcher icon keytip
 
-You can add keytip to the launcher icon by using the `launcherIconKeyTip` property.
+You can add keytip to the launcher icon by using the [launcherIconKeyTip](https://ej2.syncfusion.com/documentation/api/ribbon/ribbonGroup/#keytip) property.
 
 {% tabs %}
 {% highlight ts tabtitle="index.ts" %}
@@ -89,6 +89,18 @@ You can add keytip to the launcher icon by using the `launcherIconKeyTip` proper
 {% endtabs %}
           
 {% previewsample "page.domainurl/code-snippet/ribbon/launcher-keytip" %}
+
+## Methods
+
+### Show keytips
+
+You can use the [showKeyTips](https://ej2.syncfusion.com/documentation/api/ribbon/ribbonKeyTip/#showkeytips) method to shown the keytips dynamically.
+
+In order to show specific keytips, pass the key string as an argument in the `showKeyTips` method.
+
+### Hide keytips
+
+You can remove the keytips dynamically using the [hideKeyTips](https://ej2.syncfusion.com/documentation/api/ribbon/ribbonKeyTip/#hidekeytips) method in the Ribbon. This will remove all the visible keytips.
 
 ## Guidelines for adding keytips
 

--- a/ej2-javascript/ribbon/ts/modules.md
+++ b/ej2-javascript/ribbon/ts/modules.md
@@ -22,8 +22,11 @@ The following modules are available in Ribbon. If the module injection type is *
 | `RibbonComboBox` | To use the built-in combobox as a ribbon item. | default |
 | `RibbonGroupButton` | To use the built-in groupbutton as a ribbon item. | default |
 | `RibbonColorPicker` | Inject this module to use the built-in colorpicker as a ribbon item.| selective |
+| `RibbonGallery` | Inject this module to use the built-in gallery as a ribbon item.| selective |
 | `RibbonFileMenu` | Inject this module to use the file menu feature.| selective |
 | `RibbonBackstage` | Inject this module to use the backstage view feature.| selective |
+| `RibbonContextualTab` | Inject this module to use the contextual tab feature.| selective |
+| `RibbonKeyTip` | Inject this module to use the keytip feature.| selective |
 
 These selective modules should be injected into the Ribbon using the `Ribbon.Inject` method.
 

--- a/ej2-javascript/ribbon/ts/modules.md
+++ b/ej2-javascript/ribbon/ts/modules.md
@@ -22,7 +22,7 @@ The following modules are available in Ribbon. If the module injection type is *
 | `RibbonComboBox` | To use the built-in combobox as a ribbon item. | default |
 | `RibbonGroupButton` | To use the built-in groupbutton as a ribbon item. | default |
 | `RibbonColorPicker` | Inject this module to use the built-in colorpicker as a ribbon item.| selective |
-| `RibbonGallery` | Inject this module to use the built-in gallery as a ribbon item.| selective |
+| `RibbonGallery` | Inject this module to use the gallery as a ribbon item.| selective |
 | `RibbonFileMenu` | Inject this module to use the file menu feature.| selective |
 | `RibbonBackstage` | Inject this module to use the backstage view feature.| selective |
 | `RibbonContextualTab` | Inject this module to use the contextual tab feature.| selective |


### PR DESCRIPTION
### Description
Need to add UG content for the Ribbon Keytip.

**Keytip**

- Items Keytip
- Filemenu Keytip
- Backstage ment Keytip
- Layout switcher Keytip
- Launcher Icon Keytip
- Methods
   - Show keytips
   - Hide keytips 

**Screenshot**
**Filemenu keytip**
<img width="956" alt="image" src="https://github.com/syncfusion-content/ej2-navigations-docs/assets/111413468/3761b921-8fea-4b0c-ac3c-879de4c9d8e7">

**Backstage keytip**
<img width="790" alt="image" src="https://github.com/syncfusion-content/ej2-navigations-docs/assets/111413468/869308e3-c758-456f-b6c1-aaef047080ec">

**Layout switcher keytip**
<img width="956" alt="image" src="https://github.com/syncfusion-content/ej2-navigations-docs/assets/111413468/9afd0f4b-70b4-4f4c-92f3-e044f62f4477">

**Items keytip**
<img width="953" alt="image" src="https://github.com/syncfusion-content/ej2-navigations-docs/assets/111413468/6c9aa24f-1300-4099-ba7a-e6b6bb16b33a">

**Launcher icon keytip**
<img width="954" alt="image" src="https://github.com/syncfusion-content/ej2-navigations-docs/assets/111413468/e2c1509c-01b0-473b-8634-20faaaa21d76">

