### PR TITLE
docs(865635): Fixed the template sample issue in ug.

### DIFF
--- a/ej2-javascript/code-snippet/ribbon/gallery/galleryTemplate/index.js
+++ b/ej2-javascript/code-snippet/ribbon/gallery/galleryTemplate/index.js
@@ -49,7 +49,6 @@ var tabs = [
                   itemCount: 7,
                   groups: [{
                     header: 'Plain Tables',
-                    itemHeight: "79",
                     items: [
                       {
                         cssClass: "plainTables_item_1"
@@ -75,7 +74,6 @@ var tabs = [
                     ]
                   }, {
                     header: 'List Tables',
-                    itemHeight: "79",
                     items: [
                       {
                         cssClass: "listTables_item_1"

--- a/ej2-javascript/code-snippet/ribbon/gallery/galleryTemplate/index.ts
+++ b/ej2-javascript/code-snippet/ribbon/gallery/galleryTemplate/index.ts
@@ -53,7 +53,6 @@ let tabs: RibbonTabModel[] = [
                   itemCount: 7,
                   groups: [{
                     header: 'Plain Tables',
-                    itemHeight: "79",
                     items: [
                       {
                         cssClass: "plainTables_item_1"
@@ -79,7 +78,6 @@ let tabs: RibbonTabModel[] = [
                     ]
                   }, {
                     header: 'List Tables',
-                    itemHeight: "79",
                     items: [
                       {
                         cssClass: "listTables_item_1"


### PR DESCRIPTION
### Description
Need to fix the preview sample not working in template sample in ug.
Item height property is not needed here as we have provided max-height for the items.


### Screenshot
**Before**
![image](https://github.com/syncfusion-content/ej2-navigations-docs/assets/119287329/05449414-f1f5-4aaa-acc7-434a7acb84ab)

**After**
![image](https://github.com/syncfusion-content/ej2-navigations-docs/assets/119287329/6083b7e5-d51d-485b-95af-bcc60b28e534)
